### PR TITLE
fix(credential-proxy): prepend upstream URL path to forwarded requests

### DIFF
--- a/src/credential-proxy.ts
+++ b/src/credential-proxy.ts
@@ -79,11 +79,16 @@ export function startCredentialProxy(
           }
         }
 
+        // Prepend upstream URL path so providers with a base path
+        // (e.g., https://api.z.ai/api/coding/paas/v4) work correctly.
+        const basePath = upstreamUrl.pathname.replace(/\/+$/, '');
+        const fullPath = basePath + req.url;
+
         const upstream = makeRequest(
           {
             hostname: upstreamUrl.hostname,
             port: upstreamUrl.port || (isHttps ? 443 : 80),
-            path: req.url,
+            path: fullPath,
             method: req.method,
             headers,
           } as RequestOptions,


### PR DESCRIPTION
## Summary

- Fixes a bug where the credential proxy drops the path component from the upstream base URL
- Providers with non-root base URLs (e.g., `https://api.z.ai/api/anthropic`) were getting 404s because only `req.url` (e.g., `/v1/messages`) was sent, missing the base path prefix
- Now correctly prepends `upstreamUrl.pathname` to the forwarded request path

## Context

This is a genuine bug in the credential proxy that affects any provider whose `ANTHROPIC_BASE_URL` includes a path prefix. Discovered during z.ai integration.

**Upstream-worthy** — this fix would benefit all NanoClaw users, not just our fork.

## Test plan

- [x] Tested with z.ai (`/api/anthropic` base path) — requests reach `/api/anthropic/v1/messages` correctly
- [ ] Verify with providers that have root base URLs — should be a no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)