### PR TITLE
sync: upstream qwibitai/nanoclaw v1.2.53

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,22 @@
 
 ---
 
+> **🔥 New Version Preview: Chat SDK + Approval Dialogs**
+>
+> A new version of NanoClaw is available for preview, featuring Vercel Chat SDK integration (15 messaging platforms from one codebase) and one-tap approval dialogs for sensitive agent actions. [Read the announcement →](https://venturebeat.com/orchestration/should-my-enterprise-ai-agent-do-that-nanoclaw-and-vercel-launch-easier-agentic-policy-setting-and-approval-dialogs-across-15-messaging-apps)
+>
+> <details>
+> <summary>Try the preview</summary>
+>
+> ```bash
+> gh repo fork qwibitai/nanoclaw --clone && cd nanoclaw
+> git checkout v2
+> claude
+> ```
+> Then run `/setup`. Feedback welcome on [Discord](https://discord.gg/VDdww8qS42). Expect breaking changes before merge to main.
+>
+> </details>
+
 ## Why I Built NanoClaw
 
 [OpenClaw](https://github.com/openclaw/openclaw) is an impressive project, but I wouldn't have been able to sleep if I had given complex software I didn't understand full access to my life. OpenClaw has nearly half a million lines of code, 53 config files, and 70+ dependencies. Its security is at the application level (allowlists, pairing codes) rather than true OS-level isolation. Everything runs in one Node process with shared memory.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nanoclaw",
-  "version": "1.2.52",
+  "version": "1.2.53",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nanoclaw",
-      "version": "1.2.52",
+      "version": "1.2.53",
       "dependencies": {
         "@onecli-sh/sdk": "^0.2.0",
         "better-sqlite3": "11.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nanoclaw",
-  "version": "1.2.52",
+  "version": "1.2.53",
   "description": "Personal Claude assistant. Lightweight, secure, customizable.",
   "type": "module",
   "main": "dist/index.js",

--- a/repo-tokens/badge.svg
+++ b/repo-tokens/badge.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="97" height="20" role="img" aria-label="43.7k tokens, 22% of context window">
-  <title>43.7k tokens, 22% of context window</title>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="97" height="20" role="img" aria-label="43.8k tokens, 22% of context window">
+  <title>43.8k tokens, 22% of context window</title>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
     <stop offset="1" stop-opacity=".1"/>
@@ -15,8 +15,8 @@
       <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
         <text aria-hidden="true" x="26" y="15" fill="#010101" fill-opacity=".3">tokens</text>
         <text x="26" y="14">tokens</text>
-        <text aria-hidden="true" x="74" y="15" fill="#010101" fill-opacity=".3">43.7k</text>
-        <text x="74" y="14">43.7k</text>
+        <text aria-hidden="true" x="74" y="15" fill="#010101" fill-opacity=".3">43.8k</text>
+        <text x="74" y="14">43.8k</text>
       </g>
     </g>
   </a>

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,6 +9,7 @@ const envConfig = readEnvFile([
   'ASSISTANT_NAME',
   'ASSISTANT_HAS_OWN_NUMBER',
   'ONECLI_URL',
+  'ONECLI_API_KEY',
   'TZ',
 ]);
 
@@ -52,6 +53,8 @@ export const CONTAINER_MAX_OUTPUT_SIZE = parseInt(
   10,
 ); // 10MB default
 export const ONECLI_URL = process.env.ONECLI_URL || envConfig.ONECLI_URL;
+export const ONECLI_API_KEY =
+  process.env.ONECLI_API_KEY || envConfig.ONECLI_API_KEY;
 export const MAX_MESSAGES_PER_PROMPT = Math.max(
   1,
   parseInt(process.env.MAX_MESSAGES_PER_PROMPT || '10', 10) || 10,

--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -14,6 +14,7 @@ vi.mock('./config.js', () => ({
   DATA_DIR: '/tmp/nanoclaw-test-data',
   GROUPS_DIR: '/tmp/nanoclaw-test-groups',
   IDLE_TIMEOUT: 1800000, // 30min
+  ONECLI_API_KEY: '',
   ONECLI_URL: 'http://localhost:10254',
   TIMEZONE: 'America/Los_Angeles',
 }));

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -13,6 +13,7 @@ import {
   DATA_DIR,
   GROUPS_DIR,
   IDLE_TIMEOUT,
+  ONECLI_API_KEY,
   ONECLI_URL,
   TIMEZONE,
 } from './config.js';
@@ -28,7 +29,7 @@ import { OneCLI } from '@onecli-sh/sdk';
 import { validateAdditionalMounts } from './mount-security.js';
 import { RegisteredGroup } from './types.js';
 
-const onecli = new OneCLI({ url: ONECLI_URL });
+const onecli = new OneCLI({ url: ONECLI_URL, apiKey: ONECLI_API_KEY });
 
 // Sentinel markers for robust output parsing (must match agent-runner)
 const OUTPUT_START_MARKER = '---NANOCLAW_OUTPUT_START---';


### PR DESCRIPTION
## Summary

- Merge upstream `qwibitai/nanoclaw` main into fork (5 commits : docs v2 preview, token count badge, v1.2.53 bump, `ONECLI_API_KEY` forwarding).
- 3 orthogonal conflicts resolved **dual-path** (`src/config.ts`, `src/container-runner.ts`, `src/container-runner.test.ts`) : upstream's OneCLI path kept alive alongside our credential-proxy. Switch is env-based (`ONECLI_URL` unset → credential-proxy ; set → OneCLI). Structurally aligned with upstream to keep future merges trivial.
- Package version aligned to `1.2.53`.

## What this changes

- Runtime : no behavior change. `.env` ne définit pas `ONECLI_URL` → branche credential-proxy active (comportement actuel).
- Code : `buildContainerArgs` devient `async` ; caller (`runContainerAgent`) awaite l'appel. Ajout imports `OneCLI` + `ONECLI_URL`/`ONECLI_API_KEY` + instance module-level (utilisée seulement si env var présente).
- Docs : banner v2 preview dans README upstream importé.

## Test plan

- [x] `npm run build` green
- [x] `npx vitest run` : 330/331 pass
  - Failure : `setup/platform.test.ts > commandExists > returns true for node` — pré-existant, env-specific, fichier inchangé par ce merge
  - Tests container-runner : `ONECLI_URL: ''` dans le mock pour forcer la branche credential-proxy (reflète la config prod)
- [ ] Deploy-validate avant merge main : `nssm restart NanoClaw` + watch logs Telegram reconnect

## Rollback

`git revert 81b00b3` ou reset à `5948982`.

## Divergence après merge

Fork à ~48 commits d'avance upstream avant ce PR, ~43 après (diff réduit car le merge absorbe les ajouts upstream). La résolution dual-path garantit que les prochains upstream pulls ne reconfronteront plus les mêmes conflits sur `ONECLI_*`.

Part of issue #6 (MAINTENANCE Stratégie upstream-sync — stratégie S1 validée en pratique).

🤖 Generated with [Claude Code](https://claude.com/claude-code)