### PR TITLE
fix(v2): restore IPC consumer + concurrency cap + voice/CA fixes

### DIFF
--- a/container/agent-runner/src/formatter.ts
+++ b/container/agent-runner/src/formatter.ts
@@ -227,6 +227,15 @@ function formatAttachments(attachments: any[] | undefined): string {
     const type = a.type || 'file';
     const localPath = a.localPath ? `/workspace/${a.localPath}` : '';
     const url = a.url || '';
+    // Audio attachments carry an ASR-produced `transcript` set by the host
+    // bridge (src/channels/chat-sdk-bridge.ts). Surface it inline and tell the
+    // agent the transcription is already done — otherwise it sees a bare
+    // `[audio: …]` marker, runs `file` on the path, and concludes it lacks an
+    // ASR tool, even though the transcript is right there in the inbound.
+    if (type === 'audio' && typeof a.transcript === 'string' && a.transcript.length > 0) {
+      const tail = localPath ? ` — file at ${escapeXml(localPath)}` : '';
+      return `[audio transcript (already done host-side, no further transcription needed): "${escapeXml(a.transcript)}"${tail}]`;
+    }
     if (localPath) {
       return `[${type}: ${escapeXml(name)} — saved to ${escapeXml(localPath)}]`;
     }

--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -11,6 +11,26 @@
 
 set -e
 
+# OneCLI gateway MITMs HTTPS via a self-signed CA mounted at
+# /tmp/onecli-gateway-ca.pem. Node trusts it via NODE_EXTRA_CA_CERTS, but
+# native binaries (gh, curl, git, Go-based tools) need a CA bundle that
+# combines the system roots with the gateway CA. The OneCLI SDK tries to
+# build that bundle host-side but bails on Windows because it can't find
+# the system CA path; so we build it here in the container instead.
+GATEWAY_CA="/tmp/onecli-gateway-ca.pem"
+SYSTEM_CA="/etc/ssl/certs/ca-certificates.crt"
+COMBINED_CA="/tmp/onecli-combined-ca.pem"
+if [ -r "$GATEWAY_CA" ] && [ -r "$SYSTEM_CA" ] && [ ! -f "$COMBINED_CA" ]; then
+  cat "$SYSTEM_CA" "$GATEWAY_CA" > "$COMBINED_CA" 2>/dev/null || true
+fi
+if [ -f "$COMBINED_CA" ]; then
+  # Go (gh CLI), curl, git, Python requests — all read these.
+  export SSL_CERT_FILE="$COMBINED_CA"
+  export CURL_CA_BUNDLE="$COMBINED_CA"
+  export GIT_SSL_CAINFO="$COMBINED_CA"
+  export REQUESTS_CA_BUNDLE="$COMBINED_CA"
+fi
+
 cat > /tmp/input.json
 
 exec bun run /app/src/index.ts < /tmp/input.json

--- a/src/channels/chat-sdk-bridge.ts
+++ b/src/channels/chat-sdk-bridge.ts
@@ -20,6 +20,7 @@ import { log } from '../log.js';
 import { SqliteStateAdapter } from '../state-sqlite.js';
 import { registerWebhookAdapter } from '../webhook-server.js';
 import { getAskQuestionRender } from '../db/sessions.js';
+import { isTranscriptionEnabled, transcribeAudioBuffer } from '../transcription.js';
 import { normalizeOptions, type NormalizedOption } from './ask-question.js';
 import type { ChannelAdapter, ChannelSetup, InboundMessage } from './adapter.js';
 
@@ -72,6 +73,13 @@ export interface ChatSdkBridgeConfig {
    * and reactions still target the head of the reply.
    */
   maxTextLength?: number;
+  /**
+   * Called after an audio attachment is transcribed by ASR. Lets the platform
+   * adapter echo the transcript back to the chat for user verification of
+   * transcription quality before the agent reacts. Best-effort — errors are
+   * swallowed by the caller.
+   */
+  onTranscribed?: (platformId: string, threadId: string | null, transcript: string) => Promise<void>;
 }
 
 /**
@@ -129,9 +137,10 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
     message: ChatMessage,
     isMention: boolean,
     isGroup?: boolean,
-  ): Promise<InboundMessage> {
+  ): Promise<{ inbound: InboundMessage; transcripts: string[] }> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const serialized = message.toJSON() as Record<string, any>;
+    const transcripts: string[] = [];
 
     // Download attachment data before serialization loses fetchData()
     if (message.attachments && message.attachments.length > 0) {
@@ -150,6 +159,21 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
           try {
             const buffer = await att.fetchData();
             entry.data = buffer.toString('base64');
+
+            // Transcribe audio attachments so text-only agents (no multimodal)
+            // can read voice messages. Transcript is appended to the message
+            // text AND emitted via onTranscribed so the platform can echo it
+            // back for user verification.
+            if (att.type === 'audio' && isTranscriptionEnabled()) {
+              const transcript = await transcribeAudioBuffer(buffer, att.name ?? 'voice', att.mimeType);
+              if (transcript) {
+                entry.transcript = transcript;
+                transcripts.push(transcript);
+                const existingText = typeof serialized.text === 'string' ? serialized.text : '';
+                const voiceTag = `[Voice: ${transcript}]`;
+                serialized.text = existingText ? `${existingText}\n${voiceTag}` : voiceTag;
+              }
+            }
           } catch (err) {
             log.warn('Failed to download attachment', { type: att.type, err });
           }
@@ -181,13 +205,27 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
     serialized.raw = undefined;
 
     return {
-      id: message.id,
-      kind: 'chat-sdk',
-      content: serialized,
-      timestamp: message.metadata.dateSent.toISOString(),
-      isMention,
-      isGroup,
+      inbound: {
+        id: message.id,
+        kind: 'chat-sdk',
+        content: serialized,
+        timestamp: message.metadata.dateSent.toISOString(),
+        isMention,
+        isGroup,
+      },
+      transcripts,
     };
+  }
+
+  async function notifyTranscripts(platformId: string, threadId: string | null, transcripts: string[]): Promise<void> {
+    if (!config.onTranscribed || transcripts.length === 0) return;
+    for (const t of transcripts) {
+      try {
+        await config.onTranscribed(platformId, threadId, t);
+      } catch (err) {
+        log.warn('onTranscribed echo failed', { err });
+      }
+    }
   }
 
   const bridge: ChannelAdapter = {
@@ -220,17 +258,17 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
       // wirings still fire on in-thread mentions.
       chat.onSubscribedMessage(async (thread, message) => {
         const channelId = adapter.channelIdFromThreadId(thread.id);
-        await setupConfig.onInbound(
-          channelId,
-          thread.id,
-          await messageToInbound(message, message.isMention === true, true),
-        );
+        const { inbound, transcripts } = await messageToInbound(message, message.isMention === true, true);
+        await setupConfig.onInbound(channelId, thread.id, inbound);
+        await notifyTranscripts(channelId, thread.id, transcripts);
       });
 
       // @mention in an unsubscribed thread — SDK-confirmed bot mention.
       chat.onNewMention(async (thread, message) => {
         const channelId = adapter.channelIdFromThreadId(thread.id);
-        await setupConfig.onInbound(channelId, thread.id, await messageToInbound(message, true, true));
+        const { inbound, transcripts } = await messageToInbound(message, true, true);
+        await setupConfig.onInbound(channelId, thread.id, inbound);
+        await notifyTranscripts(channelId, thread.id, transcripts);
       });
 
       // DMs — by definition addressed to the bot. Thread id flows through
@@ -245,7 +283,9 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
           sender: (message.author as any)?.fullName ?? (message.author as any)?.userId ?? 'unknown',
           threadId: thread.id,
         });
-        await setupConfig.onInbound(channelId, thread.id, await messageToInbound(message, true, false));
+        const { inbound, transcripts } = await messageToInbound(message, true, false);
+        await setupConfig.onInbound(channelId, thread.id, inbound);
+        await notifyTranscripts(channelId, thread.id, transcripts);
       });
 
       // Plain messages in unsubscribed threads.
@@ -260,7 +300,9 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
       // flood gate.
       chat.onNewMessage(/./, async (thread, message) => {
         const channelId = adapter.channelIdFromThreadId(thread.id);
-        await setupConfig.onInbound(channelId, thread.id, await messageToInbound(message, false, true));
+        const { inbound, transcripts } = await messageToInbound(message, false, true);
+        await setupConfig.onInbound(channelId, thread.id, inbound);
+        await notifyTranscripts(channelId, thread.id, transcripts);
       });
 
       // Handle button clicks (ask_user_question)

--- a/src/channels/chat-sdk-bridge.ts
+++ b/src/channels/chat-sdk-bridge.ts
@@ -293,12 +293,15 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
       // Chat SDK dispatch (handling-events.mdx §"Handler dispatch order") is
       // exclusive: subscribed → onSubscribedMessage; unsubscribed+mention →
       // onNewMention; unsubscribed+pattern-match → onNewMessage. Registering
-      // with `/./` lets the router see every plain message on every
-      // unsubscribed thread the bot can see. The router short-circuits via
-      // getMessagingGroupWithAgentCount (~1 DB read) for unwired channels,
-      // so forwarding every one is cheap enough to not need a bridge-side
-      // flood gate.
-      chat.onNewMessage(/./, async (thread, message) => {
+      // with `/.*/` lets the router see every plain message — including
+      // attachment-only messages with empty text (voice notes, stickers,
+      // photos without caption) — on every unsubscribed thread the bot can
+      // see. (`/./` would skip empty text since `.` requires at least one
+      // character, breaking voice-message ASR.) The router short-circuits
+      // via getMessagingGroupWithAgentCount (~1 DB read) for unwired
+      // channels, so forwarding every one is cheap enough to not need a
+      // bridge-side flood gate.
+      chat.onNewMessage(/.*/, async (thread, message) => {
         const channelId = adapter.channelIdFromThreadId(thread.id);
         const { inbound, transcripts } = await messageToInbound(message, false, true);
         await setupConfig.onInbound(channelId, thread.id, inbound);

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -110,6 +110,22 @@ async function sendPairingConfirmation(token: string, platformId: string): Promi
   }
 }
 
+/** Echo an ASR transcript back to the chat so the user can verify
+ *  transcription quality before the agent reacts. */
+async function sendTranscriptEcho(token: string, platformId: string, transcript: string): Promise<void> {
+  const chatId = platformId.split(':').slice(1).join(':');
+  if (!chatId) return;
+  try {
+    await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ chat_id: chatId, text: `🎤 ${transcript}` }),
+    });
+  } catch (err) {
+    log.warn('Telegram transcript echo failed', { err });
+  }
+}
+
 function createPairingInterceptor(
   botUsernamePromise: Promise<string | null>,
   hostOnInbound: ChannelSetup['onInbound'],
@@ -210,6 +226,9 @@ registerChannelAdapter('telegram', {
       extractReplyContext,
       supportsThreads: false,
       transformOutboundText: sanitizeTelegramLegacyMarkdown,
+      onTranscribed: async (platformId, _threadId, transcript) => {
+        await sendTranscriptEcho(token, platformId, transcript);
+      },
     });
 
     const botUsernamePromise = fetchBotUsername(token);

--- a/src/config.ts
+++ b/src/config.ts
@@ -38,18 +38,25 @@ export const CONTAINER_MAX_OUTPUT_SIZE = parseInt(process.env.CONTAINER_MAX_OUTP
 export const ONECLI_URL = process.env.ONECLI_URL || envConfig.ONECLI_URL;
 export const ONECLI_API_KEY = process.env.ONECLI_API_KEY || envConfig.ONECLI_API_KEY;
 
-// Local-only OneCLI policy: refuse to start the host if ONECLI_URL is missing
-// or points at the public cloud. The user explicitly forbade external fallback —
-// credentials must stay on this machine. The .onecli.sh check covers both
-// app.onecli.sh and the SDK's DEFAULT_URL fallback when the var is empty.
-if (!ONECLI_URL || /onecli\.sh/i.test(ONECLI_URL)) {
-  // eslint-disable-next-line no-console
-  console.error(
-    `[config] FATAL: ONECLI_URL must point to a local OneCLI gateway. ` +
-      `Got: ${ONECLI_URL || '(unset, SDK would fall back to https://app.onecli.sh)'}. ` +
-      `External fallback is forbidden.`,
-  );
-  process.exit(1);
+/**
+ * Local-only OneCLI policy: refuse to start the host if ONECLI_URL is missing
+ * or points at the public cloud. The user explicitly forbade external fallback —
+ * credentials must stay on this machine. Called from src/index.ts at startup
+ * (not at module-import time, so tests can import config freely).
+ *
+ * The `.onecli.sh` substring matches both app.onecli.sh and the SDK's
+ * DEFAULT_URL fallback when the var is empty.
+ */
+export function assertLocalOnecli(): void {
+  if (!ONECLI_URL || /onecli\.sh/i.test(ONECLI_URL)) {
+    // eslint-disable-next-line no-console
+    console.error(
+      `[config] FATAL: ONECLI_URL must point to a local OneCLI gateway. ` +
+        `Got: ${ONECLI_URL || '(unset, SDK would fall back to https://app.onecli.sh)'}. ` +
+        `External fallback is forbidden.`,
+    );
+    process.exit(1);
+  }
 }
 export const MAX_MESSAGES_PER_PROMPT = Math.max(1, parseInt(process.env.MAX_MESSAGES_PER_PROMPT || '10', 10) || 10);
 export const IDLE_TIMEOUT = parseInt(process.env.IDLE_TIMEOUT || '1800000', 10); // 30min default — how long to keep container alive after last result

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,7 +18,9 @@ const HOME_DIR = process.env.HOME || os.homedir();
 
 // Mount security: allowlist stored OUTSIDE project root, never mounted into containers
 export const MOUNT_ALLOWLIST_PATH = path.join(HOME_DIR, '.config', 'nanoclaw', 'mount-allowlist.json');
-export const SENDER_ALLOWLIST_PATH = path.join(HOME_DIR, '.config', 'nanoclaw', 'sender-allowlist.json');
+// (v1 SENDER_ALLOWLIST_PATH dropped — v2's unknown_sender_policy on
+// messaging_groups + agent_group_members table cover the same surface;
+// see src/modules/permissions/index.ts.)
 export const STORE_DIR = path.resolve(PROJECT_ROOT, 'store');
 export const GROUPS_DIR = path.resolve(PROJECT_ROOT, 'groups');
 export const DATA_DIR = path.resolve(PROJECT_ROOT, 'data');
@@ -35,6 +37,20 @@ export const CONTAINER_TIMEOUT = parseInt(process.env.CONTAINER_TIMEOUT || '1800
 export const CONTAINER_MAX_OUTPUT_SIZE = parseInt(process.env.CONTAINER_MAX_OUTPUT_SIZE || '10485760', 10); // 10MB default
 export const ONECLI_URL = process.env.ONECLI_URL || envConfig.ONECLI_URL;
 export const ONECLI_API_KEY = process.env.ONECLI_API_KEY || envConfig.ONECLI_API_KEY;
+
+// Local-only OneCLI policy: refuse to start the host if ONECLI_URL is missing
+// or points at the public cloud. The user explicitly forbade external fallback —
+// credentials must stay on this machine. The .onecli.sh check covers both
+// app.onecli.sh and the SDK's DEFAULT_URL fallback when the var is empty.
+if (!ONECLI_URL || /onecli\.sh/i.test(ONECLI_URL)) {
+  // eslint-disable-next-line no-console
+  console.error(
+    `[config] FATAL: ONECLI_URL must point to a local OneCLI gateway. ` +
+      `Got: ${ONECLI_URL || '(unset, SDK would fall back to https://app.onecli.sh)'}. ` +
+      `External fallback is forbidden.`,
+  );
+  process.exit(1);
+}
 export const MAX_MESSAGES_PER_PROMPT = Math.max(1, parseInt(process.env.MAX_MESSAGES_PER_PROMPT || '10', 10) || 10);
 export const IDLE_TIMEOUT = parseInt(process.env.IDLE_TIMEOUT || '1800000', 10); // 30min default — how long to keep container alive after last result
 export const MAX_CONCURRENT_CONTAINERS = Math.max(1, parseInt(process.env.MAX_CONCURRENT_CONTAINERS || '5', 10) || 5);

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -15,6 +15,7 @@ import {
   CONTAINER_INSTALL_LABEL,
   DATA_DIR,
   GROUPS_DIR,
+  MAX_CONCURRENT_CONTAINERS,
   ONECLI_API_KEY,
   ONECLI_URL,
   TIMEZONE,
@@ -83,6 +84,20 @@ export function wakeContainer(session: Session): Promise<void> {
   if (existing) {
     log.debug('Container wake already in-flight — joining existing promise', { sessionId: session.id });
     return existing;
+  }
+  // Concurrency cap: refuse to spawn beyond MAX_CONCURRENT_CONTAINERS. The
+  // host sweep (60s) re-checks countDueMessages and re-wakes once capacity
+  // frees up, so messages are never lost — just deferred. v1 did this via a
+  // GroupQueue with explicit waiting list; v2 leans on the sweep loop and
+  // keeps the runner branchless.
+  if (activeContainers.size + wakePromises.size >= MAX_CONCURRENT_CONTAINERS) {
+    log.warn('Container wake deferred — at concurrency limit', {
+      sessionId: session.id,
+      active: activeContainers.size,
+      inFlight: wakePromises.size,
+      limit: MAX_CONCURRENT_CONTAINERS,
+    });
+    return Promise.resolve();
   }
   const promise = spawnContainer(session).finally(() => {
     wakePromises.delete(session.id);
@@ -465,19 +480,23 @@ async function buildContainerArgs(
 
   // OneCLI gateway — injects HTTPS_PROXY + certs so container API calls
   // are routed through the agent vault for credential injection.
-  try {
-    if (agentIdentifier) {
-      await onecli.ensureAgent({ name: agentGroup.name, identifier: agentIdentifier });
-    }
-    const onecliApplied = await onecli.applyContainerConfig(args, { addHostMapping: false, agent: agentIdentifier });
-    if (onecliApplied) {
-      log.info('OneCLI gateway applied', { containerName });
-    } else {
-      log.warn('OneCLI gateway not applied — container will have no credentials', { containerName });
-    }
-  } catch (err) {
-    log.warn('OneCLI gateway error — container will have no credentials', { containerName, err });
+  // FAIL CLOSED: if the gateway is unreachable or returns an error, refuse to
+  // spawn rather than silently falling back to .env passthrough. The user
+  // explicitly forbade external fallback (Apr 2026) — a container without
+  // proxy + CA cert would either leak raw .env keys or hit ConnectionRefused
+  // for every API call. Better to log the spawn failure and let the human
+  // see it than to flood Telegram with API errors.
+  if (agentIdentifier) {
+    await onecli.ensureAgent({ name: agentGroup.name, identifier: agentIdentifier });
   }
+  const onecliApplied = await onecli.applyContainerConfig(args, { addHostMapping: false, agent: agentIdentifier });
+  if (!onecliApplied) {
+    throw new Error(
+      `OneCLI gateway unreachable at ${ONECLI_URL} — refusing to spawn container without credentials. ` +
+        `Check that the local gateway is running (docker compose -p onecli ps) and that the host can reach ${ONECLI_URL}/api/health.`,
+    );
+  }
+  log.info('OneCLI gateway applied', { containerName });
 
   // Host gateway
   args.push(...hostGatewayArgs());

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@
  */
 import path from 'path';
 
-import { DATA_DIR } from './config.js';
+import { DATA_DIR, assertLocalOnecli } from './config.js';
 import { migrateGroupsToClaudeLocal } from './claude-md-compose.js';
 import { initDb } from './db/connection.js';
 import { runMigrations } from './db/migrations/index.js';
@@ -58,6 +58,11 @@ import { initChannelAdapters, teardownChannelAdapters, getChannelAdapter } from 
 
 async function main(): Promise<void> {
   log.info('NanoClaw starting');
+
+  // 0. Refuse to run if ONECLI_URL points at the cloud (or is unset). This is
+  //    a runtime check rather than a module-load assertion so tests and tools
+  //    can import ./config freely without an env var.
+  assertLocalOnecli();
 
   // 1. Init central DB
   const dbPath = path.join(DATA_DIR, 'v2.db');

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { runMigrations } from './db/migrations/index.js';
 import { ensureContainerRuntimeRunning, cleanupOrphans } from './container-runtime.js';
 import { startActiveDeliveryPoll, startSweepDeliveryPoll, setDeliveryAdapter, stopDeliveryPolls } from './delivery.js';
 import { startHostSweep, stopHostSweep } from './host-sweep.js';
+import { startIpcWatcher, stopIpcWatcher } from './ipc-watcher.js';
 import { routeInbound } from './router.js';
 import { log } from './log.js';
 
@@ -159,6 +160,10 @@ async function main(): Promise<void> {
   startHostSweep();
   log.info('Host sweep started');
 
+  // 7. Start IPC watcher (consumes data/ipc/<folder>/messages/*.json from
+  //    out-of-process producers like roosync-inbox-standalone).
+  startIpcWatcher();
+
   log.info('NanoClaw running');
 }
 
@@ -174,6 +179,7 @@ async function shutdown(signal: string): Promise<void> {
   }
   stopDeliveryPolls();
   stopHostSweep();
+  stopIpcWatcher();
   await teardownChannelAdapters();
   process.exit(0);
 }

--- a/src/ipc-watcher.ts
+++ b/src/ipc-watcher.ts
@@ -1,0 +1,240 @@
+/**
+ * IPC watcher — polls `data/ipc/<folder>/messages/*.json` and injects
+ * synthetic messages directly into the agent's session inbound DB.
+ *
+ * Used by out-of-process producers (NSSM-managed `roosync-inbox-standalone`,
+ * external scripts) to wake an agent without going through a chat platform.
+ *
+ * **Trust model:** IPC files come from local services running under the
+ * same Windows account as nanoclaw — file system permissions ARE the auth
+ * boundary. We therefore bypass `routeInbound` (which runs the
+ * access-gate / unknown-sender / engage-mode checks meant for untrusted
+ * platform input) and write directly via `writeSessionMessage` + spawn the
+ * container via `wakeContainer`. This matches v1 `storeMessageDirect`
+ * semantics and explicitly accepts the trade-off: any local code with
+ * write access to `data/ipc/` can wake any agent — that's the same trust
+ * level as anything that can already touch `data/v2.db` or session DBs.
+ *
+ * Currently handles `inject_synthetic_message` only — the path used by the
+ * RooSync inbox watcher to surface cross-machine dashboard mentions. The v1
+ * `message` type (cross-group send) is not ported because no producer in
+ * this repo emits it; route through the channel adapter directly if needed.
+ */
+import fs from 'fs';
+import path from 'path';
+
+import { DATA_DIR } from './config.js';
+import { getAgentGroupByFolder } from './db/agent-groups.js';
+import { getMessagingGroupsByAgentGroup } from './db/messaging-groups.js';
+import { findSessionByAgentGroup } from './db/sessions.js';
+import { log } from './log.js';
+import { resolveSession, writeSessionMessage } from './session-manager.js';
+import { wakeContainer } from './container-runner.js';
+
+const POLL_INTERVAL_MS = 15_000;
+
+let timer: NodeJS.Timeout | null = null;
+let stopped = false;
+
+interface InboxMsg {
+  id: string;
+  from: string;
+  to?: string;
+  subject?: string;
+  body?: string;
+  tags?: string[];
+  priority?: string;
+}
+
+interface InjectSyntheticMessage {
+  type: 'inject_synthetic_message';
+  inboxMsg: InboxMsg;
+}
+
+export function startIpcWatcher(): void {
+  const baseDir = path.join(DATA_DIR, 'ipc');
+  fs.mkdirSync(baseDir, { recursive: true });
+  log.info('IPC watcher started', { baseDir, pollMs: POLL_INTERVAL_MS });
+
+  const loop = async (): Promise<void> => {
+    if (stopped) return;
+    try {
+      await pollOnce(baseDir);
+    } catch (err) {
+      log.error('IPC watcher loop error', { err });
+    }
+    if (!stopped) timer = setTimeout(loop, POLL_INTERVAL_MS);
+  };
+  timer = setTimeout(loop, POLL_INTERVAL_MS);
+}
+
+export function stopIpcWatcher(): void {
+  stopped = true;
+  if (timer) clearTimeout(timer);
+  timer = null;
+}
+
+async function pollOnce(baseDir: string): Promise<void> {
+  if (!fs.existsSync(baseDir)) return;
+  const folders = fs
+    .readdirSync(baseDir, { withFileTypes: true })
+    .filter((d) => d.isDirectory() && d.name !== 'errors')
+    .map((d) => d.name);
+
+  for (const folder of folders) {
+    const messagesDir = path.join(baseDir, folder, 'messages');
+    if (!fs.existsSync(messagesDir)) continue;
+    let files: string[];
+    try {
+      files = fs.readdirSync(messagesDir).filter((f) => f.endsWith('.json'));
+    } catch (err) {
+      log.error('IPC: readdir failed', { folder, err });
+      continue;
+    }
+    for (const file of files) {
+      const filePath = path.join(messagesDir, file);
+      try {
+        const raw = fs.readFileSync(filePath, 'utf-8');
+        const data = JSON.parse(raw);
+        const handled = await processIpcMessage(folder, data);
+        if (handled) {
+          fs.unlinkSync(filePath);
+        } else {
+          // Unrecognized payload — quarantine so we don't re-process forever.
+          quarantine(baseDir, folder, file, filePath, 'unrecognized payload');
+        }
+      } catch (err) {
+        log.error('IPC: error processing file', { folder, file, err });
+        quarantine(baseDir, folder, file, filePath, String(err));
+      }
+    }
+  }
+}
+
+function quarantine(baseDir: string, folder: string, file: string, filePath: string, reason: string): void {
+  const errorsDir = path.join(baseDir, folder, 'errors');
+  try {
+    fs.mkdirSync(errorsDir, { recursive: true });
+    fs.renameSync(filePath, path.join(errorsDir, file));
+    log.warn('IPC: file quarantined', { folder, file, reason });
+  } catch (err) {
+    log.error('IPC: quarantine failed', { folder, file, reason, err });
+  }
+}
+
+async function processIpcMessage(folder: string, data: unknown): Promise<boolean> {
+  if (!data || typeof data !== 'object') return false;
+  const obj = data as Partial<InjectSyntheticMessage>;
+  if (obj.type !== 'inject_synthetic_message' || !obj.inboxMsg) return false;
+  const inboxMsg = obj.inboxMsg;
+
+  const ag = getAgentGroupByFolder(folder);
+  if (!ag) {
+    log.warn('IPC inject: no agent group for folder', { folder, msgId: inboxMsg.id });
+    return true; // consume — no point retrying when wiring is absent
+  }
+
+  // Resolve a target session. Prefer an existing active session for this
+  // agent group (typical case: one shared session per cluster manager
+  // install). Fall back to creating one against the first wired messaging
+  // group so the synthetic message reaches the right container even on a
+  // cold install that hasn't seen any traffic yet.
+  let session = findSessionByAgentGroup(ag.id);
+  let mgChannelType: string | null = null;
+  let mgPlatformId: string | null = null;
+
+  if (!session) {
+    const mgs = getMessagingGroupsByAgentGroup(ag.id);
+    if (mgs.length === 0) {
+      log.warn('IPC inject: no messaging group wired and no active session', {
+        folder,
+        agentGroupId: ag.id,
+        msgId: inboxMsg.id,
+      });
+      return true;
+    }
+    const mg = mgs[0];
+    const resolved = resolveSession(ag.id, mg.id, null, 'shared');
+    session = resolved.session;
+    mgChannelType = mg.channel_type;
+    mgPlatformId = mg.platform_id;
+  } else {
+    // Look up the messaging group attached to this session for routing
+    // metadata. Fall back to the first wired one when the session predates
+    // a messaging group rename / re-wire.
+    const mgs = getMessagingGroupsByAgentGroup(ag.id);
+    const sessionMg = mgs.find((m) => m.id === session!.messaging_group_id) ?? mgs[0];
+    if (sessionMg) {
+      mgChannelType = sessionMg.channel_type;
+      mgPlatformId = sessionMg.platform_id;
+    }
+  }
+
+  const shortBody = (inboxMsg.body ?? '').replace(/\s+/g, ' ').trim().slice(0, 400);
+  const tagsSuffix = inboxMsg.tags?.length ? ` [${inboxMsg.tags.join(', ')}]` : '';
+  const text =
+    `[roosync-inbox] Nouvelle mention RooSync reçue.\n\n` +
+    `From: ${inboxMsg.from}\nSubject: ${inboxMsg.subject ?? ''}${tagsSuffix}\nMessageId: ${inboxMsg.id}\n\n` +
+    `Extrait: ${shortBody}\n\n` +
+    `Lis ton inbox (roosync_read mode:"inbox") et agis selon le contenu.`;
+
+  const nowIso = new Date().toISOString();
+  const syntheticId = `roosync-${inboxMsg.id}`;
+  const chatMsg = {
+    _type: 'chat:Message',
+    id: syntheticId,
+    threadId: mgPlatformId ?? '',
+    text,
+    author: {
+      userId: 'roosync-inbox',
+      userName: 'RooSync Inbox',
+      fullName: 'RooSync Inbox',
+      isBot: false,
+      isMe: false,
+    },
+    metadata: { dateSent: nowIso, edited: false },
+    attachments: [],
+    isMention: true,
+    senderId: 'system:roosync-inbox',
+    sender: 'RooSync Inbox',
+    senderName: 'RooSync Inbox',
+  };
+
+  try {
+    writeSessionMessage(ag.id, session.id, {
+      id: syntheticId,
+      kind: 'chat-sdk',
+      timestamp: nowIso,
+      platformId: mgPlatformId,
+      channelType: mgChannelType,
+      threadId: null,
+      content: JSON.stringify(chatMsg),
+      trigger: 1,
+    });
+  } catch (err) {
+    log.error('IPC: writeSessionMessage failed', {
+      folder,
+      msgId: inboxMsg.id,
+      sessionId: session.id,
+      err,
+    });
+    return false; // quarantine — likely transient; retry next poll cycle
+  }
+
+  // Fire-and-forget container wake. wakeContainer is async and may need to
+  // pull the image / bind-mount config; surfacing failures here would block
+  // the next poll, and the host sweep will also wake on its 60s schedule.
+  void wakeContainer(session).catch((err) =>
+    log.warn('IPC: wakeContainer failed (host sweep will retry)', { sessionId: session.id, err }),
+  );
+
+  log.info('IPC injected synthetic message', {
+    folder,
+    msgId: inboxMsg.id,
+    syntheticId,
+    agentGroupId: ag.id,
+    sessionId: session.id,
+  });
+
+  return true;
+}

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -249,15 +249,21 @@ function extractAttachmentFiles(
   const attachments = parsed.attachments as Array<Record<string, unknown>> | undefined;
   if (!Array.isArray(attachments)) return contentStr;
 
+  // Windows forbids `< > : " | ? *` and 0x00-0x1F in path components.
+  // Telegram (and other adapters) use ':' as a separator in message IDs,
+  // so we must sanitize before mkdir. Both the on-disk dir and the
+  // localPath written to inbound.db use the same sanitized form.
+  const safeMessageId = messageId.replace(/[<>:"|?*\x00-\x1f]/g, '_');
+
   let changed = false;
   for (const att of attachments) {
     if (typeof att.data === 'string') {
-      const inboxDir = path.join(sessionDir(agentGroupId, sessionId), 'inbox', messageId);
+      const inboxDir = path.join(sessionDir(agentGroupId, sessionId), 'inbox', safeMessageId);
       fs.mkdirSync(inboxDir, { recursive: true });
       const filename = (att.name as string) || `attachment-${Date.now()}`;
       const filePath = path.join(inboxDir, filename);
       fs.writeFileSync(filePath, Buffer.from(att.data as string, 'base64'));
-      att.localPath = `inbox/${messageId}/${filename}`;
+      att.localPath = `inbox/${safeMessageId}/${filename}`;
       delete att.data;
       changed = true;
       log.debug('Saved attachment to inbox', { messageId, filename, size: att.size });

--- a/src/transcription.ts
+++ b/src/transcription.ts
@@ -1,0 +1,116 @@
+import { log } from './log.js';
+import { readEnvFile } from './env.js';
+
+interface AsrConfig {
+  baseUrl: string;
+  apiKey: string;
+  model: string;
+}
+
+let cachedConfig: AsrConfig | null | undefined = undefined;
+
+function loadConfig(): AsrConfig | null {
+  if (cachedConfig !== undefined) return cachedConfig;
+
+  const env = readEnvFile(['ASR_BASE_URL', 'ASR_API_KEY', 'ASR_MODEL']);
+  const baseUrl = process.env.ASR_BASE_URL || env.ASR_BASE_URL;
+  const apiKey = process.env.ASR_API_KEY || env.ASR_API_KEY;
+
+  if (!baseUrl || !apiKey) {
+    cachedConfig = null;
+    return null;
+  }
+
+  cachedConfig = {
+    baseUrl: baseUrl.replace(/\/+$/, ''),
+    apiKey,
+    model: process.env.ASR_MODEL || env.ASR_MODEL || 'whisper-1',
+  };
+  return cachedConfig;
+}
+
+export function isTranscriptionEnabled(): boolean {
+  return loadConfig() !== null;
+}
+
+/**
+ * Transcribe an in-memory audio buffer via an OpenAI-compatible
+ * /audio/transcriptions endpoint. Returns transcript text, or null if
+ * transcription is disabled or fails.
+ *
+ * v2 chat-sdk-bridge already holds the audio buffer from att.fetchData() —
+ * no disk round-trip needed. Bearer auth via ASR_API_KEY, endpoint via
+ * ASR_BASE_URL (e.g. https://whisper-api.myia.io/v1). Supports ogg/opus
+ * directly (faster-whisper decodes natively).
+ */
+export async function transcribeAudioBuffer(
+  buffer: Buffer,
+  filename: string,
+  mimeType?: string,
+): Promise<string | null> {
+  const config = loadConfig();
+  if (!config) return null;
+
+  try {
+    const mime = mimeType || mimeForExt(extFromName(filename));
+    const form = new FormData();
+    form.append('file', new Blob([buffer], { type: mime }), filename);
+    form.append('model', config.model);
+
+    const url = `${config.baseUrl}/audio/transcriptions`;
+    const resp = await fetch(url, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${config.apiKey}` },
+      body: form,
+    });
+
+    if (!resp.ok) {
+      const body = await resp.text().catch(() => '');
+      log.warn('Transcription request failed', { status: resp.status, body: body.slice(0, 200) });
+      return null;
+    }
+
+    const data = (await resp.json()) as { text?: string };
+    const text = (data.text || '').trim();
+    if (!text) {
+      log.debug('Transcription returned empty text', { filename });
+      return null;
+    }
+
+    log.info('Transcribed voice message', { filename, chars: text.length });
+    return text;
+  } catch (err) {
+    log.error('Transcription error', { filename, err });
+    return null;
+  }
+}
+
+function extFromName(name: string): string {
+  const idx = name.lastIndexOf('.');
+  return idx >= 0 ? name.slice(idx).toLowerCase() : '';
+}
+
+function mimeForExt(ext: string): string {
+  switch (ext) {
+    case '.ogg':
+    case '.oga':
+      return 'audio/ogg';
+    case '.opus':
+      return 'audio/opus';
+    case '.mp3':
+      return 'audio/mpeg';
+    case '.wav':
+      return 'audio/wav';
+    case '.m4a':
+      return 'audio/mp4';
+    case '.flac':
+      return 'audio/flac';
+    default:
+      return 'application/octet-stream';
+  }
+}
+
+/** For tests: reset cached config so env changes take effect. */
+export function resetTranscriptionConfigForTests(): void {
+  cachedConfig = undefined;
+}

--- a/src/transcription.ts
+++ b/src/transcription.ts
@@ -5,6 +5,8 @@ interface AsrConfig {
   baseUrl: string;
   apiKey: string;
   model: string;
+  language?: string;
+  prompt?: string;
 }
 
 let cachedConfig: AsrConfig | null | undefined = undefined;
@@ -12,7 +14,7 @@ let cachedConfig: AsrConfig | null | undefined = undefined;
 function loadConfig(): AsrConfig | null {
   if (cachedConfig !== undefined) return cachedConfig;
 
-  const env = readEnvFile(['ASR_BASE_URL', 'ASR_API_KEY', 'ASR_MODEL']);
+  const env = readEnvFile(['ASR_BASE_URL', 'ASR_API_KEY', 'ASR_MODEL', 'ASR_LANGUAGE', 'ASR_PROMPT']);
   const baseUrl = process.env.ASR_BASE_URL || env.ASR_BASE_URL;
   const apiKey = process.env.ASR_API_KEY || env.ASR_API_KEY;
 
@@ -25,6 +27,8 @@ function loadConfig(): AsrConfig | null {
     baseUrl: baseUrl.replace(/\/+$/, ''),
     apiKey,
     model: process.env.ASR_MODEL || env.ASR_MODEL || 'whisper-1',
+    language: process.env.ASR_LANGUAGE || env.ASR_LANGUAGE || undefined,
+    prompt: process.env.ASR_PROMPT || env.ASR_PROMPT || undefined,
   };
   return cachedConfig;
 }
@@ -56,6 +60,10 @@ export async function transcribeAudioBuffer(
     const form = new FormData();
     form.append('file', new Blob([buffer], { type: mime }), filename);
     form.append('model', config.model);
+    // language hint stops Whisper from misdetecting the language on short
+    // clips (auto-detection is unreliable below ~5s of speech).
+    if (config.language) form.append('language', config.language);
+    if (config.prompt) form.append('prompt', config.prompt);
 
     const url = `${config.baseUrl}/audio/transcriptions`;
     const resp = await fetch(url, {


### PR DESCRIPTION
## Summary

Bundles four commits restoring v1 functionality lost in the v2 rewrite + cluster-ops fixes that surfaced this week:

- **IPC consumer (`src/ipc-watcher.ts`, new file)** — host now polls `data/ipc/<folder>/messages/*.json` every 15s and injects synthetic chat-sdk messages directly into the session inbound DB (bypassing `routeInbound`'s access gate, since file-system perms are the auth boundary). Previously `roosync-inbox-standalone` wrote files that were dropped on the floor.
- **MAX_CONCURRENT_CONTAINERS guard (`src/container-runner.ts`)** — the constant was defined in `config.ts` but never read; cluster bursts could OOM the host. `wakeContainer` now refuses to spawn beyond the cap and the 60s sweep retries when capacity frees.
- **Voice/audio transcription (`container/agent-runner/src/formatter.ts` + `src/channels/chat-sdk-bridge.ts`)** — formatter surfaces the host-side ASR transcript inline so the agent doesn't redundantly try `file` on the path; chat-sdk-bridge regex `/./` → `/.*/` so caption-less voice notes (empty text) are captured at all.
- **Combined CA bundle in container (`container/entrypoint.sh`)** — OneCLI SDK's host-side bundler bails on Windows hosts, so `gh` / `curl` / `git` / Python hit 401 on TLS. Entrypoint now builds `SSL_CERT_FILE` / `CURL_CA_BUNDLE` / `GIT_SSL_CAINFO` / `REQUESTS_CA_BUNDLE` inside the container from system roots + gateway CA.
- **OneCLI fail-closed (`src/config.ts` + `src/index.ts`)** — `assertLocalOnecli()` refuses to start the host if `ONECLI_URL` is missing or points at `*.onecli.sh`. Called from `index.ts` at startup (not at import-time, so tests/tools can import config freely).
- **Cleanup**: drop dead `SENDER_ALLOWLIST_PATH` (v2's `unknown_sender_policy` + `agent_group_members` cover the same surface).
- **Other hardening**: Windows path sanitization for Telegram message IDs (`:` is forbidden on NTFS), `ASR_LANGUAGE` / `ASR_PROMPT` env passthrough.

Verified end-to-end: dropped a synthetic IPC file, watcher consumed it within one poll cycle (15s), row landed in inbound.db with correct chat-sdk shape, container spawned 34ms after injection.

## Test plan

- [x] `pnpm run build` clean
- [x] `pnpm test` 229 pass, 9 pre-existing Windows-EPERM flakes in scheduling tests (filesystem race on `D:\tmp\nanoclaw-recurrence-test` — predates this PR, unrelated)
- [x] CI green after the OneCLI assertion was moved out of module-load path
- [x] IPC smoke test: synthetic message → inbound.db → container wake (34ms)
- [x] Service restart: `IPC watcher started` log line + no error cascade
- [ ] Live voice-message round-trip (next Telegram audio post should now have transcript inline)

## Audit honnête v1→v2

Le contexte : l'utilisateur s'est plaint à plusieurs reprises qu'on découvrait des trous v1→v2 au compte-goutte. J'ai donc fait une passe exhaustive avec un sous-agent comparant `src/v1/` à `src/`. Le sous-agent a sorti une liste de ~13 candidats. Voici la classification honnête :

### ✅ Inclus dans cette PR (régressions réelles)

| Gap | Sévérité | Impact concret | Fix |
|-----|----------|----------------|-----|
| **IPC consumer** absent | **critique** | Tout le trafic `roosync-inbox-standalone` (cluster inter-machines) silencieusement perdu — fichiers écrits, jamais lus | `src/ipc-watcher.ts` polleur 15s + `writeSessionMessage` + `wakeContainer` |
| **MAX_CONCURRENT_CONTAINERS** déclaré non-utilisé | haute | Burst de 5+ messages → 5+ containers Docker en parallèle → OOM host (vu en prod sur le cluster) | Garde dans `wakeContainer`, sweep 60s reprend |
| **Voice/audio transcript** manquant côté formatter | haute | Agent reçoit `[audio: voice.ogg — saved to /workspace/...]` sans le texte, perd 100% du contenu utile | Affiche `[audio transcript: "..."]` inline |
| **Empty-text messages** filtrés par regex bridge | haute | Notes vocales sans légende (cas standard Telegram) jamais routées | Regex `/./` → `/.*/` |
| **CA bundle Windows** non monté pour binaires natifs | haute | `gh` / `curl` / `git` / Python tous 401 sur TLS dans containers | Combiné dans entrypoint, exporté via 4 env vars standards |
| **Telegram message IDs** avec `:` cassent les paths Windows | moyenne | Création session échoue silencieusement sur `\session\<id>:<num>\` | Sanitization `[<>:"|?*\x00-\x1f]` → `_` |

### ✅ Inclus (durcissements liés mais pas régressions)

| Item | Pourquoi |
|------|----------|
| **OneCLI fail-closed** | Demande utilisateur explicite : "credentials must stay on this machine" — refus de fallback `app.onecli.sh` |
| **`SENDER_ALLOWLIST_PATH` mort** | Constante définie, jamais lue ailleurs — `unknown_sender_policy` + `agent_group_members` la remplacent |
| **`ASR_LANGUAGE` / `ASR_PROMPT`** | v1 les exposait, v2 les avait perdus en chemin lors du portage Whisper→Qwen3-ASR |

### ❌ Non inclus, **v2-by-design** (pas des régressions)

| v1 feature | Pourquoi pas ramené |
|------------|---------------------|
| **`sender-allowlist.json`** par chat | Remplacé par `unknown_sender_policy` (`strict`/`request_approval`/`public`) sur `messaging_groups` + table `agent_group_members`. Modèle plus riche : portée user-level, pas chat-level. |
| **Credential proxy host-side** | Déplacé dans OneCLI gateway intentionnellement (voir [CLAUDE.md](CLAUDE.md#secrets--credentials--onecli)). Vault central, secrets injectés par requête, jamais via env vars. |
| **`GroupQueue` class** (waiting list explicite) | Remplacée par sweep loop 60s + concurrency cap. Plus simple, branchless, "messages never lost — just deferred". |
| **`NANOCLAW_ADMIN_USER_IDS` env var** | Remplacé par `user_roles` table (owner / admin global / admin scoped). Persisté en DB, plus modifiable à chaud, sans redémarrage. |

### ⏳ Régressions réelles **non incluses dans cette PR** (follow-up)

Bundler ces items aurait gonflé la review surface inutilement :

| Item | Sévérité | Action de suivi |
|------|----------|-----------------|
| `task_run_logs` table absente | observabilité (pas de blast radius prod) | PR séparée — restaurer schéma + logger côté `delivery.ts`/`host-sweep.ts` |
| `/remote-control` filtré sans handler | basse (commande admin rare) | Soit supprimer du `ADMIN_COMMANDS`, soit restaurer le handler v1 |
| `scripts/cleanup-sessions.sh` référence `data/sessions/` | maintenance | Porter vers `data/v2-sessions/` (split inbound/outbound) |
| Snapshots `available_groups.json` / `current_tasks.json` | inconnu | Investiguer consommateurs avant de décider — peut être totalement mort |

### Méthodologie

- Sous-agent `general-purpose` a comparé `src/v1/` (preserved) vs `src/` (current) avec lecture des fichiers + grep des appels
- Pour chaque gap, j'ai vérifié manuellement : (1) le code v1 fait bien ce qu'on dit ? (2) le remplaçant v2 existe-t-il ? (3) le test du remplaçant couvre-t-il le cas v1 ?
- Les "v2-by-design" sont sourcés dans CLAUDE.md ou les migrations DB

Pas une garantie absolue d'exhaustivité — un sous-agent peut rater des choses — mais la passe est documentée et reproductible.

## Branch protection

Branch protection est active sur `main`. Cette PR doit être reviewée avant merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
