### PR TITLE
feat(agent-runner): restore task_run_logs observability surface

### DIFF
--- a/container/agent-runner/src/db/connection.ts
+++ b/container/agent-runner/src/db/connection.ts
@@ -74,6 +74,23 @@ export function getOutboundDb(): Database {
         updated_at               TEXT NOT NULL
       );
     `);
+    // task_run_logs: one row per scheduled-task occurrence the agent processes.
+    // Restores the v1 observability surface (v1 had this in store/messages.db).
+    // Container is the sole writer; the agent reads it via list_task_runs MCP.
+    _outbound.exec(`
+      CREATE TABLE IF NOT EXISTS task_run_logs (
+        id           INTEGER PRIMARY KEY AUTOINCREMENT,
+        task_id      TEXT NOT NULL,
+        series_id    TEXT,
+        run_at       TEXT NOT NULL,
+        duration_ms  INTEGER NOT NULL,
+        status       TEXT NOT NULL,
+        result       TEXT,
+        error        TEXT
+      );
+      CREATE INDEX IF NOT EXISTS idx_task_run_logs_task   ON task_run_logs(task_id, run_at);
+      CREATE INDEX IF NOT EXISTS idx_task_run_logs_series ON task_run_logs(series_id, run_at);
+    `);
   }
   return _outbound;
 }

--- a/container/agent-runner/src/db/messages-in.ts
+++ b/container/agent-runner/src/db/messages-in.ts
@@ -18,6 +18,7 @@ export interface MessageInRow {
   status: string;
   process_after: string | null;
   recurrence: string | null;
+  series_id: string | null;
   tries: number;
   /** 1 = wake-eligible (default); 0 = accumulated context only */
   trigger: number;

--- a/container/agent-runner/src/db/task-run-logs.ts
+++ b/container/agent-runner/src/db/task-run-logs.ts
@@ -1,0 +1,77 @@
+/**
+ * task_run_logs — execution history for scheduled tasks.
+ *
+ * Restores the v1 surface (`store/messages.db.task_run_logs`) lost in the
+ * v2 rewrite. One row per occurrence of a task message processed by the
+ * container. `task_id` is the message id; `series_id` ties recurring
+ * occurrences together (matches the v2 messages_in.series_id semantics).
+ *
+ * The container is the sole writer — see connection.ts for the table
+ * bootstrap, and the poll-loop for write call sites.
+ */
+import { getOutboundDb } from './connection.js';
+
+export interface TaskRunLog {
+  id: number;
+  task_id: string;
+  series_id: string | null;
+  run_at: string;
+  duration_ms: number;
+  status: 'completed' | 'failed' | 'skipped';
+  result: string | null;
+  error: string | null;
+}
+
+export interface RecordTaskRunInput {
+  task_id: string;
+  series_id?: string | null;
+  run_at: string;
+  duration_ms: number;
+  status: 'completed' | 'failed' | 'skipped';
+  result?: string | null;
+  error?: string | null;
+}
+
+export function recordTaskRun(input: RecordTaskRunInput): void {
+  getOutboundDb()
+    .prepare(
+      `INSERT INTO task_run_logs (task_id, series_id, run_at, duration_ms, status, result, error)
+       VALUES ($task_id, $series_id, $run_at, $duration_ms, $status, $result, $error)`,
+    )
+    .run({
+      $task_id: input.task_id,
+      $series_id: input.series_id ?? null,
+      $run_at: input.run_at,
+      $duration_ms: input.duration_ms,
+      $status: input.status,
+      $result: input.result ?? null,
+      $error: input.error ?? null,
+    });
+}
+
+export interface ListTaskRunsOptions {
+  taskOrSeriesId?: string;
+  limit?: number;
+}
+
+/**
+ * List task runs, newest first. When `taskOrSeriesId` is set, matches both
+ * `task_id` (single occurrence) and `series_id` (any occurrence in a
+ * recurring series) so the agent can pass the id from list_tasks without
+ * caring which it is.
+ */
+export function listTaskRuns(opts: ListTaskRunsOptions = {}): TaskRunLog[] {
+  const limit = Math.max(1, Math.min(opts.limit ?? 50, 500));
+  const db = getOutboundDb();
+  if (opts.taskOrSeriesId) {
+    return db
+      .prepare(
+        `SELECT * FROM task_run_logs
+          WHERE task_id = ? OR series_id = ?
+          ORDER BY run_at DESC
+          LIMIT ?`,
+      )
+      .all(opts.taskOrSeriesId, opts.taskOrSeriesId, limit) as TaskRunLog[];
+  }
+  return db.prepare(`SELECT * FROM task_run_logs ORDER BY run_at DESC LIMIT ?`).all(limit) as TaskRunLog[];
+}

--- a/container/agent-runner/src/mcp-tools/scheduling.ts
+++ b/container/agent-runner/src/mcp-tools/scheduling.ts
@@ -8,6 +8,7 @@
 import { getInboundDb } from '../db/connection.js';
 import { writeMessageOut } from '../db/messages-out.js';
 import { getSessionRouting } from '../db/session-routing.js';
+import { listTaskRuns } from '../db/task-run-logs.js';
 import { TIMEZONE, parseZonedToUtc } from '../timezone.js';
 import { registerTools } from './server.js';
 import type { McpToolDefinition } from './types.js';
@@ -296,4 +297,39 @@ export const updateTask: McpToolDefinition = {
   },
 };
 
-registerTools([scheduleTask, listTasks, updateTask, cancelTask, pauseTask, resumeTask]);
+export const listTaskRunsTool: McpToolDefinition = {
+  tool: {
+    name: 'list_task_runs',
+    description:
+      'List execution history for scheduled tasks. Returns one row per task occurrence the container processed (newest first), including duration and final status. Pass `taskId` (the series id from list_tasks, or a single occurrence id) to filter; omit it to see the most recent runs across all tasks.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        taskId: {
+          type: 'string',
+          description: 'Optional task or series id (matches both task_id and series_id). Omit to see all recent runs.',
+        },
+        limit: {
+          type: 'number',
+          description: 'Max rows to return (default 50, capped at 500).',
+        },
+      },
+    },
+  },
+  async handler(args) {
+    const taskId = args.taskId as string | undefined;
+    const limit = typeof args.limit === 'number' ? args.limit : undefined;
+    const rows = listTaskRuns({ taskOrSeriesId: taskId, limit });
+    if (rows.length === 0) {
+      return ok(taskId ? `No runs found for task ${taskId}.` : 'No task runs recorded yet.');
+    }
+    const lines = rows.map((r) => {
+      const head = `${r.run_at} [${r.status}] ${r.task_id}${r.series_id ? ` (series ${r.series_id})` : ''} — ${r.duration_ms}ms`;
+      const detail = r.error ? `\n    error: ${r.error.slice(0, 200)}` : '';
+      return head + detail;
+    });
+    return ok(lines.join('\n'));
+  },
+};
+
+registerTools([scheduleTask, listTasks, listTaskRunsTool, updateTask, cancelTask, pauseTask, resumeTask]);

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -2,6 +2,7 @@ import { findByName, getAllDestinations, type DestinationEntry } from './destina
 import { getPendingMessages, markProcessing, markCompleted, type MessageInRow } from './db/messages-in.js';
 import { writeMessageOut } from './db/messages-out.js';
 import { touchHeartbeat, clearStaleProcessingAcks } from './db/connection.js';
+import { recordTaskRun } from './db/task-run-logs.js';
 import {
   clearContinuation,
   migrateLegacyContinuation,
@@ -131,6 +132,11 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
       continue;
     }
 
+    // Snapshot tasks before pre-task scripts run so we can attribute the
+    // skipped/completed/failed status correctly to each task row in the
+    // task_run_logs table afterwards.
+    const tasksInBatch = normalMessages.filter((m) => m.kind === 'task');
+
     // Pre-task scripts: for any task rows with a `script`, run it before the
     // provider call. Scripts returning wakeAgent=false (or erroring) gate
     // their own task row only — surviving messages still go to the agent.
@@ -146,6 +152,19 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
     if (skipped.length > 0) {
       markCompleted(skipped);
       log(`Pre-task script skipped ${skipped.length} task(s): ${skipped.join(', ')}`);
+      // Log skipped tasks. Duration is approximate (the pre-task script
+      // ran but we don't capture its individual time here); use 0 as a
+      // placeholder — the meaningful field is status='skipped'.
+      const skippedSet = new Set(skipped);
+      for (const task of tasksInBatch.filter((t) => skippedSet.has(t.id))) {
+        recordTaskRun({
+          task_id: task.id,
+          series_id: task.series_id,
+          run_at: new Date().toISOString(),
+          duration_ms: 0,
+          status: 'skipped',
+        });
+      }
     }
     // MODULE-HOOK:scheduling-pre-task:end
 
@@ -170,6 +189,9 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
     // Process the query while concurrently polling for new messages
     const skippedSet = new Set(skipped);
     const processingIds = ids.filter((id) => !commandIds.includes(id) && !skippedSet.has(id));
+    const tasksKept = tasksInBatch.filter((t) => !skippedSet.has(t.id));
+    const batchStartedAt = Date.now();
+    let batchError: string | null = null;
     try {
       const result = await processQuery(query, routing, processingIds, config.providerName);
       if (result.continuation && result.continuation !== continuation) {
@@ -179,6 +201,7 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
     } catch (err) {
       const errMsg = err instanceof Error ? err.message : String(err);
       log(`Query error: ${errMsg}`);
+      batchError = errMsg;
 
       // Stale/corrupt continuation recovery: ask the provider whether
       // this error means the stored continuation is unusable, and clear
@@ -204,6 +227,26 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
     // (e.g. stream closed unexpectedly).
     markCompleted(processingIds);
     log(`Completed ${ids.length} message(s)`);
+
+    // Log task runs for any task messages that went through the agent.
+    // Duration is the batch processing time — when several tasks ride
+    // along in one prompt, they share that time, which is a faithful
+    // record of "this is how long the agent spent producing the reply
+    // covering this task."
+    if (tasksKept.length > 0) {
+      const runAt = new Date(batchStartedAt).toISOString();
+      const durationMs = Date.now() - batchStartedAt;
+      for (const task of tasksKept) {
+        recordTaskRun({
+          task_id: task.id,
+          series_id: task.series_id,
+          run_at: runAt,
+          duration_ms: durationMs,
+          status: batchError ? 'failed' : 'completed',
+          error: batchError,
+        });
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Restores the `task_run_logs` table that v1 had in `store/messages.db` (one row per scheduled-task occurrence) — gone in the v2 rewrite. The bot can now answer "did task X actually run? when? did it succeed?" via a clean MCP tool.

### Where the table lives

In **outbound.db**, not central. Reasoning:
- Container is the only process that knows when a task started/finished and how long it took.
- Outbound.db is the only DB the container can write to (per the v2 two-DB split).
- The agent reads from outbound.db too, so a single source of truth, no cross-DB hop.
- Trade-off: cross-session aggregation isn't supported. In practice each agent group has one long-lived session, so the same outbound.db accumulates the full history the agent needs.

### Schema (created on demand)

```sql
CREATE TABLE IF NOT EXISTS task_run_logs (
  id           INTEGER PRIMARY KEY AUTOINCREMENT,
  task_id      TEXT NOT NULL,        -- messages_in.id (single occurrence)
  series_id    TEXT,                 -- messages_in.series_id (recurring family)
  run_at       TEXT NOT NULL,
  duration_ms  INTEGER NOT NULL,
  status       TEXT NOT NULL,        -- completed | failed | skipped
  result       TEXT,
  error        TEXT
);
CREATE INDEX idx_task_run_logs_task   ON task_run_logs(task_id, run_at);
CREATE INDEX idx_task_run_logs_series ON task_run_logs(series_id, run_at);
```

### Where the writes happen

In `poll-loop.ts`:
- `status='completed'` after the agent finishes a batch that contained task messages
- `status='failed'` with the error message if `processQuery` throws
- `status='skipped'` when the pre-task script gates the row (returns `wakeAgent=false`)

Duration is the **batch processing time** — when several tasks ride along in the same prompt they share that duration. That's a faithful record: "the agent spent X ms producing the reply that covers this task."

### What the agent gets

New MCP tool `list_task_runs(taskId?, limit?)`:
- `taskId`: optional. Matches **both** `task_id` and `series_id` so the agent can pass whatever id it has from `list_tasks` without thinking.
- `limit`: clamped to [1, 500], default 50.
- Returns newest first, with a one-line-per-run rendering (`run_at [status] task_id (series ...) — durationMs`), `error` excerpted on failures.

### Test plan

- [x] `pnpm run build` clean
- [x] `pnpm test` 229 pass / 9 pre-existing Windows-EPERM scheduling flakes (unrelated)
- [ ] Container typecheck via `bun typecheck` — Bun isn't installed on this Windows host, will rely on CI
- [ ] Live verification: trigger one one-shot task and one recurring task, then call `list_task_runs` from chat — confirm rows appear

### Out of scope (follow-ups)

- Host-side writes (would let the host log container crashes that never produced any agent output). Defer until we have a concrete need.
- Cross-session aggregation (would require central DB or DB-per-agent-group).
- `result` column population (currently always NULL — could put a truncated agent reply, but that duplicates `messages_out`). Defer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)