### PR TITLE
fix(v2/agent-runner): build allowedTools dynamically from configured MCP servers

### DIFF
--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -34,8 +34,12 @@ const SDK_DISALLOWED_TOOLS = [
   'ExitWorktree',
 ];
 
-// Tool allowlist for NanoClaw agent containers
-const TOOL_ALLOWLIST = [
+// Static (non-MCP) tool allowlist for NanoClaw agent containers.
+// MCP entries are appended per-instance from the configured mcpServers map
+// (see ClaudeProvider constructor) — Claude Code 2.1.116+ treats
+// `--allowedTools` as a hard whitelist, so any MCP server not listed here
+// has its child process never spawned, regardless of `bypassPermissions`.
+const STATIC_TOOL_ALLOWLIST = [
   'Bash',
   'Read',
   'Write',
@@ -54,7 +58,6 @@ const TOOL_ALLOWLIST = [
   'ToolSearch',
   'Skill',
   'NotebookEdit',
-  'mcp__nanoclaw__*',
 ];
 
 interface SDKUserMessage {
@@ -243,6 +246,7 @@ export class ClaudeProvider implements AgentProvider {
   private mcpServers: Record<string, McpServerConfig>;
   private env: Record<string, string | undefined>;
   private additionalDirectories?: string[];
+  private allowedTools: string[];
 
   constructor(options: ProviderOptions = {}) {
     this.assistantName = options.assistantName;
@@ -252,6 +256,10 @@ export class ClaudeProvider implements AgentProvider {
       ...(options.env ?? {}),
       CLAUDE_CODE_AUTO_COMPACT_WINDOW,
     };
+    this.allowedTools = [
+      ...STATIC_TOOL_ALLOWLIST,
+      ...Object.keys(this.mcpServers).map((name) => `mcp__${name}__*`),
+    ];
   }
 
   isSessionInvalid(err: unknown): boolean {
@@ -273,7 +281,7 @@ export class ClaudeProvider implements AgentProvider {
         resume: input.continuation,
         pathToClaudeCodeExecutable: '/pnpm/claude',
         systemPrompt: instructions ? { type: 'preset' as const, preset: 'claude_code' as const, append: instructions } : undefined,
-        allowedTools: TOOL_ALLOWLIST,
+        allowedTools: this.allowedTools,
         disallowedTools: SDK_DISALLOWED_TOOLS,
         env: this.env,
         permissionMode: 'bypassPermissions',


### PR DESCRIPTION
## Summary

Claude Code 2.1.116+ treats `--allowedTools` as a **hard whitelist**: any MCP server not matched by the list has its mcp-remote child process never spawned, even under `permissionMode: bypassPermissions`. The previous static `TOOL_ALLOWLIST` hard-coded only `mcp__nanoclaw__*`, which silently broke `roo-state-manager` and `sk-agent` MCPs — they appeared as **"No such tool available"** because their bridges were never started.

Regression introduced when agent-runner's claude-code dep was bumped 2.1.112 → 2.1.116 (commit 63b8beb upstream); 2.1.112 treated `allowedTools` as an auto-approve hint rather than a strict whitelist.

## Fix

Compute the per-instance allowlist by appending `mcp__<name>__*` for each configured MCP server in `ClaudeProvider`'s constructor, drawn from `options.mcpServers` (built-in `nanoclaw` + every entry in `container.json` mcpServers).

## Verification (live, end-to-end)

1. Old container: `ps -ef` showed nanoclaw mcp child only; no mcp-remote for roo-state-manager / sk-agent.
2. Applied fix (source mounted RO → no image rebuild needed).
3. Stopped container; injected synthetic IPC test.
4. Fresh container `--allowedTools` ends with `,mcp__nanoclaw__*,mcp__roo-state-manager__*,mcp__sk-agent__*`.
5. `ps -ef` shows mcp-remote children for both external servers.
6. Bot called `mcp__roo-state-manager__roosync_dashboard(action="read", type="workspace")` → 35ms, full workspace data returned.

## Test plan

- [x] Host tests unaffected (change is in container/agent-runner/, host doesn't import it)
- [x] Live: synthetic IPC test against fresh container spawn → tool call succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)