### PR TITLE
fix(v2): keep heartbeat fresh across tool calls + widen ceiling for any tool

### DIFF
--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -3,7 +3,7 @@ import path from 'path';
 
 import { query as sdkQuery, type HookCallback, type PreCompactHookInput } from '@anthropic-ai/claude-agent-sdk';
 
-import { clearContainerToolInFlight, setContainerToolInFlight } from '../db/connection.js';
+import { clearContainerToolInFlight, setContainerToolInFlight, touchHeartbeat } from '../db/connection.js';
 import { registerProvider } from './provider-registry.js';
 import type { AgentProvider, AgentQuery, McpServerConfig, ProviderEvent, ProviderOptions, QueryInput } from './types.js';
 
@@ -145,36 +145,54 @@ function formatTranscriptMarkdown(messages: ParsedMessage[], title?: string | nu
 }
 
 /**
- * PreToolUse hook: record the current tool + its declared timeout so the host
- * sweep can widen its stuck tolerance while Bash is running a long-declared
- * script. Defense-in-depth: if SDK_DISALLOWED_TOOLS slips through somehow,
- * block the call here instead of letting the agent hang.
+ * PreToolUse hook factory: record the current tool + its declared timeout so
+ * the host sweep can widen its stuck tolerance while a long tool runs. The
+ * declared timeout is read from `tool_input.timeout` for Bash, and from the
+ * MCP server config for `mcp__<server>__*` tools — without it, an MCP that
+ * legitimately takes >30 min racing against the absolute-ceiling kill (see
+ * incident 2026-04-26: sk-agent.list_agents hung in mcp-remote bridge,
+ * heartbeat stalled, host killed at the same instant the SDK would have
+ * timed out internally). Also touches the heartbeat so the kill clock starts
+ * fresh from tool start. Defense-in-depth: if SDK_DISALLOWED_TOOLS slips
+ * through somehow, block the call here instead of letting the agent hang.
  */
-const preToolUseHook: HookCallback = async (input) => {
-  const i = input as { tool_name?: string; tool_input?: Record<string, unknown> };
-  const toolName = i.tool_name ?? '';
-  if (SDK_DISALLOWED_TOOLS.includes(toolName)) {
-    return {
-      decision: 'block',
-      stopReason: `Tool '${toolName}' is not available in this environment — use the nanoclaw equivalent.`,
-    } as unknown as ReturnType<HookCallback>;
-  }
-  // Bash exposes its timeout via the tool_input.timeout field (ms). Any other
-  // tool: no declared timeout.
-  const declaredTimeoutMs =
-    toolName === 'Bash' && typeof i.tool_input?.timeout === 'number' ? (i.tool_input.timeout as number) : null;
-  try {
-    setContainerToolInFlight(toolName, declaredTimeoutMs);
-  } catch (err) {
-    log(`PreToolUse: failed to record container_state: ${err instanceof Error ? err.message : String(err)}`);
-  }
-  return { continue: true };
-};
+function createPreToolUseHook(mcpServers: Record<string, McpServerConfig>): HookCallback {
+  return async (input) => {
+    const i = input as { tool_name?: string; tool_input?: Record<string, unknown> };
+    const toolName = i.tool_name ?? '';
+    if (SDK_DISALLOWED_TOOLS.includes(toolName)) {
+      return {
+        decision: 'block',
+        stopReason: `Tool '${toolName}' is not available in this environment — use the nanoclaw equivalent.`,
+      } as unknown as ReturnType<HookCallback>;
+    }
+    let declaredTimeoutMs: number | null = null;
+    if (toolName === 'Bash' && typeof i.tool_input?.timeout === 'number') {
+      declaredTimeoutMs = i.tool_input.timeout as number;
+    } else if (toolName.startsWith('mcp__')) {
+      const serverName = toolName.split('__')[1];
+      const serverCfg = serverName ? mcpServers[serverName] : undefined;
+      const cfgTimeout = (serverCfg as { timeout?: number } | undefined)?.timeout;
+      if (typeof cfgTimeout === 'number') declaredTimeoutMs = cfgTimeout * 1000;
+    }
+    try {
+      setContainerToolInFlight(toolName, declaredTimeoutMs);
+      touchHeartbeat();
+    } catch (err) {
+      log(`PreToolUse: failed to record container_state: ${err instanceof Error ? err.message : String(err)}`);
+    }
+    return { continue: true };
+  };
+}
 
-/** Clear in-flight tool on PostToolUse / PostToolUseFailure. */
+/**
+ * Clear in-flight tool on PostToolUse / PostToolUseFailure. Refreshes the
+ * heartbeat so the next tool/turn gets a fresh kill window.
+ */
 const postToolUseHook: HookCallback = async () => {
   try {
     clearContainerToolInFlight();
+    touchHeartbeat();
   } catch (err) {
     log(`PostToolUse: failed to clear container_state: ${err instanceof Error ? err.message : String(err)}`);
   }
@@ -289,7 +307,7 @@ export class ClaudeProvider implements AgentProvider {
         settingSources: ['project', 'user'],
         mcpServers: this.mcpServers,
         hooks: {
-          PreToolUse: [{ hooks: [preToolUseHook] }],
+          PreToolUse: [{ hooks: [createPreToolUseHook(this.mcpServers)] }],
           PostToolUse: [{ hooks: [postToolUseHook] }],
           PostToolUseFailure: [{ hooks: [postToolUseHook] }],
           PreCompact: [{ hooks: [createPreCompactHook(this.assistantName)] }],

--- a/src/host-sweep.ts
+++ b/src/host-sweep.ts
@@ -74,7 +74,7 @@ export function decideStuckAction(args: {
   claims: Array<{ message_id: string; status_changed: string }>;
 }): StuckDecision {
   const { now, heartbeatMtimeMs, containerState, claims } = args;
-  const declaredBashMs = bashTimeoutMs(containerState);
+  const declaredToolMs = declaredToolTimeoutMs(containerState);
 
   // Ceiling check only applies when we have an actual heartbeat timestamp.
   // A freshly-spawned container hasn't had any SDK activity yet so no
@@ -86,13 +86,13 @@ export function decideStuckAction(args: {
   // claim-stuck check below handles it.
   if (heartbeatMtimeMs !== 0) {
     const heartbeatAge = now - heartbeatMtimeMs;
-    const ceiling = Math.max(ABSOLUTE_CEILING_MS, declaredBashMs ?? 0);
+    const ceiling = Math.max(ABSOLUTE_CEILING_MS, declaredToolMs ?? 0);
     if (heartbeatAge > ceiling) {
       return { action: 'kill-ceiling', heartbeatAgeMs: heartbeatAge, ceilingMs: ceiling };
     }
   }
 
-  const tolerance = Math.max(CLAIM_STUCK_MS, declaredBashMs ?? 0);
+  const tolerance = Math.max(CLAIM_STUCK_MS, declaredToolMs ?? 0);
   for (const claim of claims) {
     const claimedAt = Date.parse(claim.status_changed);
     if (Number.isNaN(claimedAt)) continue;
@@ -206,8 +206,8 @@ function heartbeatMtimeMs(agentGroupId: string, sessionId: string): number {
   }
 }
 
-function bashTimeoutMs(state: ContainerState | null): number | null {
-  if (!state || state.current_tool !== 'Bash') return null;
+function declaredToolTimeoutMs(state: ContainerState | null): number | null {
+  if (!state || !state.current_tool) return null;
   return typeof state.tool_declared_timeout_ms === 'number' ? state.tool_declared_timeout_ms : null;
 }
 


### PR DESCRIPTION
## Summary

Stabilization fix for the container-froze-on-MCP-call-then-killed-by-ceiling failure mode.

**Incident** (2026-04-26): At 18:40 Paris the agent called `mcp__sk-agent__list_agents`; the `mcp-remote` bridge hung. The SDK emitted no events for ~30 min, the heartbeat (only refreshed on SDK events) went stale, and the host's 30 min absolute-ceiling kill raced the SDK's own 1800 s MCP timeout — they fired together so the agent neither timed the call out nor reported the failure. Container killed code 137; no respawn (the only "due" work was the message that had just been ack'd-but-never-replied). Bot silent ~30 min.

## Three changes

1. **`container/agent-runner/src/providers/claude.ts`** — `Pre/PostToolUse` hooks now call `touchHeartbeat()`. Each tool start/end is proof-of-liveness, so a tool gets the full `ABSOLUTE_CEILING_MS` window from its own start instead of inheriting prior heartbeat lag.

2. **`container/agent-runner/src/providers/claude.ts`** — `PreToolUse` declares the configured MCP timeout (ms) to `container_state` for any `mcp__<server>__*` tool. Previously only Bash's `tool_input.timeout` was reported, so MCPs were treated as zero-declared-timeout against the static 30 min ceiling.

3. **`src/host-sweep.ts`** — `bashTimeoutMs` → `declaredToolTimeoutMs`. Any tool with a declared timeout widens both the kill ceiling and the per-claim stuck tolerance, not just Bash. No semantic change for tools that don't set a timeout.

## Out of scope

Lowering per-group MCP timeouts (`sk-agent` 1800→300 s, `roo-state-manager` 1800→600 s) was applied locally in `groups/telegram_main/container.json` (gitignored). Other installs pick their own values.

## Test plan

- [x] Host typecheck (`pnpm exec tsc --noEmit`) clean
- [x] `pnpm exec vitest run src/host-sweep` — 10/10 pass
- [x] Restart host service, inject IPC stability test message: container spawned 19:33:41, replied 19:35:37 (1m56s incl. cold start), `container_state.updated_at` advancing per-tool-call (hooks fired as expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)