### PR TITLE
fix(v2): apply CA bundle setup in dynamic container spawn

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -525,7 +525,23 @@ async function buildContainerArgs(
   const imageTag = containerConfig.imageTag || CONTAINER_IMAGE;
   args.push(imageTag);
 
-  args.push('-c', 'exec bun run /app/src/index.ts');
+  // OneCLI gateway MITMs HTTPS via a self-signed CA mounted at
+  // /tmp/onecli-gateway-ca.pem. Native binaries (gh, curl, git, Python)
+  // need a CA bundle that combines the system roots with the gateway CA;
+  // the SDK's host-side bundler bails on Windows. We replicate the same
+  // setup container/entrypoint.sh does, since this dynamic-spawn path
+  // overrides --entrypoint and doesn't run entrypoint.sh.
+  args.push(
+    '-c',
+    [
+      'GATEWAY_CA="/tmp/onecli-gateway-ca.pem"',
+      'SYSTEM_CA="/etc/ssl/certs/ca-certificates.crt"',
+      'COMBINED_CA="/tmp/onecli-combined-ca.pem"',
+      'if [ -r "$GATEWAY_CA" ] && [ -r "$SYSTEM_CA" ] && [ ! -f "$COMBINED_CA" ]; then cat "$SYSTEM_CA" "$GATEWAY_CA" > "$COMBINED_CA" 2>/dev/null || true; fi',
+      'if [ -f "$COMBINED_CA" ]; then export SSL_CERT_FILE="$COMBINED_CA" CURL_CA_BUNDLE="$COMBINED_CA" GIT_SSL_CAINFO="$COMBINED_CA" REQUESTS_CA_BUNDLE="$COMBINED_CA"; fi',
+      'exec bun run /app/src/index.ts',
+    ].join('; '),
+  );
 
   return args;
 }


### PR DESCRIPTION
## Summary

The bot reported on the `workspace-nanoclaw` dashboard at `2026-04-26T17:35:13Z` that `SSL_CERT_FILE`, `CURL_CA_BUNDLE`, and `GIT_SSL_CAINFO` were `NOT_SET` in its container — only `NODE_EXTRA_CA_CERTS` was set. As a result, `gh`, `curl`, `git` and Python tools couldn't TLS to the OneCLI gateway.

PR #10 added the combined-CA-bundle setup to `container/entrypoint.sh`, but the dynamic-spawn path in [src/container-runner.ts:521-528](src/container-runner.ts#L521-L528) overrides `--entrypoint` with `bash -c 'exec bun run /app/src/index.ts'`, which **bypasses entrypoint.sh entirely**. So the fix from #10 never reached the running container in v2.

## Fix

Inline the same combined-CA-bundle setup directly in the bash command used for dynamic spawn, so both code paths produce identical env. Keeps `exec bun ...` so signals still forward cleanly.

## Test plan
- [x] `pnpm run build` — clean
- [x] `npx vitest run src/container-runner.test.ts` — 6/6 pass
- [ ] Service restart, send test Telegram message, verify `gh pr list --repo jsboige/nanoclaw` works inside the new container without `--insecure`
- [ ] Verify the bot's MCP roo-state-manager calls also work (same CA bundle covers them)

🤖 Generated with [Claude Code](https://claude.com/claude-code)