### PR TITLE
fix(v2/roosync-inbox): restore TS source + accept in-container bot identity

### DIFF
--- a/src/roosync-inbox-standalone.ts
+++ b/src/roosync-inbox-standalone.ts
@@ -1,0 +1,276 @@
+import fs from 'fs';
+import path from 'path';
+
+import { readEnvFile } from './env.js';
+
+const env = readEnvFile([
+  'ROOSYNC_SHARED_PATH',
+  'ROOSYNC_MACHINE_ID',
+  'ROOSYNC_WORKSPACE',
+  'ROOSYNC_INBOX_POLL_INTERVAL',
+  'ROOSYNC_INBOX_EXTRA_TARGETS',
+]);
+
+const SHARED = process.env.ROOSYNC_SHARED_PATH || env.ROOSYNC_SHARED_PATH || '';
+const MACHINE = process.env.ROOSYNC_MACHINE_ID || env.ROOSYNC_MACHINE_ID || '';
+const WORKSPACE = process.env.ROOSYNC_WORKSPACE || env.ROOSYNC_WORKSPACE || '';
+const EXTRA_TARGETS_RAW =
+  process.env.ROOSYNC_INBOX_EXTRA_TARGETS ||
+  env.ROOSYNC_INBOX_EXTRA_TARGETS ||
+  '';
+const POLL_MS = Math.max(
+  1000,
+  parseInt(
+    process.env.ROOSYNC_INBOX_POLL_INTERVAL ||
+      env.ROOSYNC_INBOX_POLL_INTERVAL ||
+      '15000',
+    10,
+  ) || 15000,
+);
+const MAIN_GROUP_FOLDER =
+  process.env.ROOSYNC_INBOX_IPC_GROUP_FOLDER || 'telegram_main';
+const DATA_DIR = path.resolve(process.cwd(), 'data');
+
+const CUTOFF_DAYS = 3;
+const PROCESSED_MAX = 500;
+
+const INBOX_DIR = path.join(SHARED, 'messages', 'inbox');
+// The host machine's RooSync identity (e.g. "nanoclaw-cluster:nanoclaw") is the
+// primary target. But the bot inside the agent container signs its dashboard
+// posts with a *different* identity (e.g. "nanoclaw:agent") — see the
+// `lastModifiedBy` of workspace-nanoclaw.md. Mentions addressed to that
+// in-container identity must also wake the bot, otherwise dashboard
+// `mentions:` aimed at the bot's own user-id are silently dropped.
+//
+// ROOSYNC_INBOX_EXTRA_TARGETS is a comma-separated list of additional
+// "machineId:workspace" pairs the watcher will also accept.
+const EXPECTED_TARGETS = new Set<string>(
+  [
+    `${MACHINE}:${WORKSPACE}`,
+    ...EXTRA_TARGETS_RAW.split(',').map((s) => s.trim()),
+  ].filter((t) => t.length > 0 && t.includes(':')),
+);
+const IPC_MESSAGES_DIR = path.join(
+  DATA_DIR,
+  'ipc',
+  MAIN_GROUP_FOLDER,
+  'messages',
+);
+const STATE_FILE = path.join(DATA_DIR, 'roosync-inbox-processed.json');
+
+function log(level: 'info' | 'warn' | 'error', data: Record<string, unknown>) {
+  const line = JSON.stringify({
+    ts: new Date().toISOString(),
+    level,
+    component: 'roosync-inbox-standalone',
+    ...data,
+  });
+  if (level === 'error') process.stderr.write(line + '\n');
+  else process.stdout.write(line + '\n');
+}
+
+if (!SHARED || !MACHINE || !WORKSPACE) {
+  log('error', {
+    msg: 'missing config, exiting',
+    hasShared: Boolean(SHARED),
+    hasMachine: Boolean(MACHINE),
+    hasWorkspace: Boolean(WORKSPACE),
+  });
+  process.exit(1);
+}
+
+fs.mkdirSync(IPC_MESSAGES_DIR, { recursive: true });
+fs.mkdirSync(DATA_DIR, { recursive: true });
+
+function computeCutoffPrefix(now: Date, days: number): string {
+  const cutoff = new Date(now.getTime() - days * 24 * 60 * 60 * 1000);
+  const y = cutoff.getUTCFullYear();
+  const m = String(cutoff.getUTCMonth() + 1).padStart(2, '0');
+  const d = String(cutoff.getUTCDate()).padStart(2, '0');
+  return `msg-${y}${m}${d}`;
+}
+
+function loadProcessed(): Set<string> {
+  try {
+    if (!fs.existsSync(STATE_FILE)) return new Set();
+    const parsed = JSON.parse(fs.readFileSync(STATE_FILE, 'utf-8')) as {
+      ids?: string[];
+    };
+    if (Array.isArray(parsed.ids))
+      return new Set(parsed.ids.slice(-PROCESSED_MAX));
+  } catch (err) {
+    log('warn', {
+      msg: 'failed to load state',
+      err: err instanceof Error ? err.message : String(err),
+    });
+  }
+  return new Set();
+}
+
+function saveProcessed(ids: Set<string>): void {
+  try {
+    const tmp = `${STATE_FILE}.tmp`;
+    fs.writeFileSync(tmp, JSON.stringify({ ids: [...ids] }, null, 2));
+    fs.renameSync(tmp, STATE_FILE);
+  } catch (err) {
+    log('error', {
+      msg: 'failed to save state',
+      err: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+let processedIds = loadProcessed();
+let missingDirLogged = false;
+let stopped = false;
+
+function pollOnce(): void {
+  if (!fs.existsSync(INBOX_DIR)) {
+    if (!missingDirLogged) {
+      log('warn', {
+        msg: 'inbox directory not accessible',
+        inboxDir: INBOX_DIR,
+      });
+      missingDirLogged = true;
+    }
+    return;
+  }
+  missingDirLogged = false;
+
+  let files: string[];
+  try {
+    files = fs.readdirSync(INBOX_DIR);
+  } catch (err) {
+    log('error', {
+      msg: 'readdir failed',
+      inboxDir: INBOX_DIR,
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return;
+  }
+
+  const cutoff = computeCutoffPrefix(new Date(), CUTOFF_DAYS);
+
+  for (const f of files) {
+    if (!f.startsWith('msg-') || !f.endsWith('.json')) continue;
+    if (f < cutoff) continue;
+    const id = f.slice(0, -5);
+    if (processedIds.has(id)) continue;
+
+    const full = path.join(INBOX_DIR, f);
+    let raw: string;
+    try {
+      raw = fs.readFileSync(full, 'utf-8');
+    } catch (err) {
+      log('warn', {
+        msg: 'read failed',
+        file: f,
+        err: err instanceof Error ? err.message : String(err),
+      });
+      processedIds.add(id);
+      continue;
+    }
+
+    let msg: {
+      id?: string;
+      from?: string;
+      to?: string;
+      subject?: string;
+      body?: string;
+      tags?: string[];
+      timestamp?: string;
+      priority?: string;
+      status?: string;
+    };
+    try {
+      msg = JSON.parse(raw);
+    } catch (err) {
+      log('warn', {
+        msg: 'parse failed',
+        file: f,
+        err: err instanceof Error ? err.message : String(err),
+      });
+      processedIds.add(id);
+      continue;
+    }
+
+    if (!msg || !msg.id || !msg.to || !msg.from) {
+      processedIds.add(id);
+      continue;
+    }
+    if (!EXPECTED_TARGETS.has(msg.to)) {
+      processedIds.add(id);
+      continue;
+    }
+
+    const ipcPayload = {
+      type: 'inject_synthetic_message',
+      inboxMsg: msg,
+      enqueued_at: new Date().toISOString(),
+    };
+    const ipcFile = path.join(IPC_MESSAGES_DIR, `roosync-${msg.id}.json`);
+    try {
+      const tmp = `${ipcFile}.tmp`;
+      fs.writeFileSync(tmp, JSON.stringify(ipcPayload, null, 2));
+      fs.renameSync(tmp, ipcFile);
+      log('info', {
+        msg: 'ipc file written',
+        msgId: msg.id,
+        from: msg.from,
+        subject: msg.subject,
+        ipcFile,
+      });
+    } catch (err) {
+      log('error', {
+        msg: 'ipc write failed',
+        file: f,
+        err: err instanceof Error ? err.message : String(err),
+      });
+      continue;
+    }
+
+    processedIds.add(id);
+  }
+
+  if (processedIds.size > PROCESSED_MAX) {
+    const sorted = [...processedIds].sort();
+    processedIds = new Set(sorted.slice(-PROCESSED_MAX));
+  }
+  saveProcessed(processedIds);
+}
+
+function loop(): void {
+  if (stopped) return;
+  try {
+    pollOnce();
+  } catch (err) {
+    log('error', {
+      msg: 'poll loop error',
+      err: err instanceof Error ? err.message : String(err),
+    });
+  }
+  setTimeout(loop, POLL_MS);
+}
+
+log('info', {
+  msg: 'started',
+  inboxDir: INBOX_DIR,
+  expectedTargets: [...EXPECTED_TARGETS],
+  pollMs: POLL_MS,
+  cutoffDays: CUTOFF_DAYS,
+  ipcDir: IPC_MESSAGES_DIR,
+  processedLoaded: processedIds.size,
+});
+
+process.on('SIGINT', () => {
+  log('info', { msg: 'SIGINT received, stopping' });
+  stopped = true;
+  process.exit(0);
+});
+process.on('SIGTERM', () => {
+  log('info', { msg: 'SIGTERM received, stopping' });
+  stopped = true;
+  process.exit(0);
+});
+
+loop();

--- a/src/roosync-inbox-standalone.ts
+++ b/src/roosync-inbox-standalone.ts
@@ -14,21 +14,12 @@ const env = readEnvFile([
 const SHARED = process.env.ROOSYNC_SHARED_PATH || env.ROOSYNC_SHARED_PATH || '';
 const MACHINE = process.env.ROOSYNC_MACHINE_ID || env.ROOSYNC_MACHINE_ID || '';
 const WORKSPACE = process.env.ROOSYNC_WORKSPACE || env.ROOSYNC_WORKSPACE || '';
-const EXTRA_TARGETS_RAW =
-  process.env.ROOSYNC_INBOX_EXTRA_TARGETS ||
-  env.ROOSYNC_INBOX_EXTRA_TARGETS ||
-  '';
+const EXTRA_TARGETS_RAW = process.env.ROOSYNC_INBOX_EXTRA_TARGETS || env.ROOSYNC_INBOX_EXTRA_TARGETS || '';
 const POLL_MS = Math.max(
   1000,
-  parseInt(
-    process.env.ROOSYNC_INBOX_POLL_INTERVAL ||
-      env.ROOSYNC_INBOX_POLL_INTERVAL ||
-      '15000',
-    10,
-  ) || 15000,
+  parseInt(process.env.ROOSYNC_INBOX_POLL_INTERVAL || env.ROOSYNC_INBOX_POLL_INTERVAL || '15000', 10) || 15000,
 );
-const MAIN_GROUP_FOLDER =
-  process.env.ROOSYNC_INBOX_IPC_GROUP_FOLDER || 'telegram_main';
+const MAIN_GROUP_FOLDER = process.env.ROOSYNC_INBOX_IPC_GROUP_FOLDER || 'telegram_main';
 const DATA_DIR = path.resolve(process.cwd(), 'data');
 
 const CUTOFF_DAYS = 3;
@@ -45,17 +36,11 @@ const INBOX_DIR = path.join(SHARED, 'messages', 'inbox');
 // ROOSYNC_INBOX_EXTRA_TARGETS is a comma-separated list of additional
 // "machineId:workspace" pairs the watcher will also accept.
 const EXPECTED_TARGETS = new Set<string>(
-  [
-    `${MACHINE}:${WORKSPACE}`,
-    ...EXTRA_TARGETS_RAW.split(',').map((s) => s.trim()),
-  ].filter((t) => t.length > 0 && t.includes(':')),
+  [`${MACHINE}:${WORKSPACE}`, ...EXTRA_TARGETS_RAW.split(',').map((s) => s.trim())].filter(
+    (t) => t.length > 0 && t.includes(':'),
+  ),
 );
-const IPC_MESSAGES_DIR = path.join(
-  DATA_DIR,
-  'ipc',
-  MAIN_GROUP_FOLDER,
-  'messages',
-);
+const IPC_MESSAGES_DIR = path.join(DATA_DIR, 'ipc', MAIN_GROUP_FOLDER, 'messages');
 const STATE_FILE = path.join(DATA_DIR, 'roosync-inbox-processed.json');
 
 function log(level: 'info' | 'warn' | 'error', data: Record<string, unknown>) {
@@ -96,8 +81,7 @@ function loadProcessed(): Set<string> {
     const parsed = JSON.parse(fs.readFileSync(STATE_FILE, 'utf-8')) as {
       ids?: string[];
     };
-    if (Array.isArray(parsed.ids))
-      return new Set(parsed.ids.slice(-PROCESSED_MAX));
+    if (Array.isArray(parsed.ids)) return new Set(parsed.ids.slice(-PROCESSED_MAX));
   } catch (err) {
     log('warn', {
       msg: 'failed to load state',


### PR DESCRIPTION
## Summary

Two bugs in one. The `roosync-inbox-standalone` watcher (Scheduled Task that bridges RooSync's shared `messages/inbox/` into NanoClaw's IPC consumer) silently dropped every dashboard mention aimed at the bot, breaking `@-mention` wake end-to-end.

- **Cause #1** — the TS source was lost during the upstream v2 sync (`a7aacf5`); only `dist/roosync-inbox-standalone.js` survived. Restored from `2fedb1a`.
- **Cause #2** — identity mismatch. The host signs as `nanoclaw-cluster:nanoclaw`, but the bot inside the agent container signs its dashboard posts as `nanoclaw:agent`. Mentions targeting the bot's user-id wrote `to: nanoclaw:agent` to the inbox, which the watcher's `if (msg.to !== EXPECTED_TO)` filter dropped.

The bot reported the symptom on Telegram this morning ("le système de réveil par mention ne fonctionne pas") despite the IPC consumer itself working fine — verified by a synthetic-file smoke test.

## Fix

Read a comma-separated `ROOSYNC_INBOX_EXTRA_TARGETS` env var and build a `Set` of accepted `machineId:workspace` pairs alongside the host's own identity. The watcher now accepts any of the listed targets. Default config in `.env` adds `nanoclaw:agent` and `nanoclaw:nanoclaw`.

## Validation (live)

| Step | Result |
|------|--------|
| Synthetic IPC file → host watcher | consumed in 3s, injected as `seq 460` on `sess-1776993077016-7qx60e` |
| Bot processed the synthetic msg | acknowledged the diagnostic in container logs |
| Dashboard mention `nanoclaw:agent` | standalone wrote IPC file at `08:39:00`, host injected synthetic msg at `08:39:03` |

Standalone restarted and now logs:
```
expectedTargets: ["nanoclaw-cluster:nanoclaw","nanoclaw:agent","nanoclaw:nanoclaw"]
```

## Test plan

- [x] TypeScript build clean
- [x] Standalone restarted with new config (PID 41880)
- [x] Smoke test (synthetic IPC file → bot wakes)
- [x] End-to-end test (dashboard mention → standalone → IPC → bot wakes)
- [ ] Bot ACK on dashboard via the new chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)