### PR TITLE
fix(v2/agent-runner): fail-fast when required MCP remotes are down

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -26,7 +26,9 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 
 import { loadConfig } from './config.js';
-import { buildSystemPromptAddendum } from './destinations.js';
+import { writeMessageOut } from './db/messages-out.js';
+import { buildSystemPromptAddendum, getAllDestinations } from './destinations.js';
+import { formatFailures, probeMcpRemote, selectRequiredRemotes, type RequiredRemote } from './mcp-health.js';
 // Providers barrel — each enabled provider self-registers on import.
 // Provider skills append imports to providers/index.ts.
 import './providers/index.js';
@@ -86,6 +88,48 @@ async function main(): Promise<void> {
     log(`Additional MCP server: ${name} (${serverConfig.command})`);
   }
 
+  // Boot-time fail-fast: probe each required mcp-remote. If anything required
+  // is unreachable, exit 1 — the host will spawn a fresh container, which
+  // re-checks. Once the chain recovers (the watchdog auto-repairs at
+  // D:\roo-extensions\scripts\mcp-watchdog\) the next boot succeeds. Surface
+  // an explicit message to the first configured destination so a human sees
+  // the halt instead of a silent loop.
+  const requiredRemotes = selectRequiredRemotes(
+    config.mcpServers as Record<string, { command: string; args: string[]; env?: Record<string, string>; required?: boolean }>,
+  );
+  if (requiredRemotes.length > 0) {
+    log(`Health-checking ${requiredRemotes.length} required MCP remote(s): ${requiredRemotes.map((r) => r.name).join(', ')}`);
+    const results = await Promise.all(
+      requiredRemotes.map(async (r) => ({ name: r.name, result: await probeMcpRemote(r.parsed) })),
+    );
+    const failed = results.filter((r) => !r.result.ok);
+    if (failed.length > 0) {
+      const failList = formatFailures(failed);
+      log(`FATAL: required MCP server(s) unreachable: ${failList}`);
+      try {
+        const dests = getAllDestinations();
+        const dest = dests[0];
+        if (dest) {
+          const platformId = dest.type === 'channel' ? dest.platformId! : dest.agentGroupId!;
+          const channelType = dest.type === 'channel' ? dest.channelType! : 'agent';
+          writeMessageOut({
+            id: `health-alert-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+            kind: 'chat',
+            platform_id: platformId,
+            channel_type: channelType,
+            content: JSON.stringify({
+              text: `🛑 Agent halted: required MCP server(s) unreachable.\n\n${failList}\n\nThe container will exit and the host will retry. If the chain stays down, manual repair is required (see watchdog log on the host).`,
+            }),
+          });
+        }
+      } catch (err) {
+        log(`Failed to write health alert: ${err instanceof Error ? err.message : String(err)}`);
+      }
+      process.exit(1);
+    }
+    log('All required MCP remotes healthy.');
+  }
+
   const provider = createProvider(providerName, {
     assistantName: config.assistantName || undefined,
     mcpServers,
@@ -98,6 +142,7 @@ async function main(): Promise<void> {
     providerName,
     cwd: CWD,
     systemContext: { instructions },
+    requiredRemotes,
   });
 }
 

--- a/container/agent-runner/src/mcp-health.test.ts
+++ b/container/agent-runner/src/mcp-health.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test, afterEach } from 'bun:test';
+
+import { clearHealthCache, parseMcpRemote, selectRequiredRemotes } from './mcp-health.js';
+
+afterEach(() => {
+  clearHealthCache();
+});
+
+describe('parseMcpRemote', () => {
+  test('extracts URL and bearer from canonical container.json form', () => {
+    const cfg = {
+      command: 'npx',
+      args: [
+        '-y',
+        'mcp-remote',
+        'https://mcp-tools.myia.io/roo-state-manager/mcp',
+        '--header',
+        'Authorization:Bearer secret-token-123',
+      ],
+    };
+    expect(parseMcpRemote(cfg)).toEqual({
+      url: 'https://mcp-tools.myia.io/roo-state-manager/mcp',
+      bearer: 'secret-token-123',
+    });
+  });
+
+  test('accepts mcp-remote without -y flag', () => {
+    const cfg = {
+      command: 'npx',
+      args: ['mcp-remote', 'https://example.com/mcp', '--header', 'Authorization:Bearer abc'],
+    };
+    expect(parseMcpRemote(cfg)).toEqual({
+      url: 'https://example.com/mcp',
+      bearer: 'abc',
+    });
+  });
+
+  test('tolerates space after Authorization colon', () => {
+    const cfg = {
+      command: 'npx',
+      args: ['-y', 'mcp-remote', 'https://x.test/mcp', '--header', 'Authorization: Bearer xyz'],
+    };
+    expect(parseMcpRemote(cfg)?.bearer).toBe('xyz');
+  });
+
+  test('returns null for non-mcp-remote configs (local stdio)', () => {
+    expect(parseMcpRemote({ command: 'bun', args: ['run', '/app/mcp-tools/index.ts'] })).toBeNull();
+    expect(parseMcpRemote({ command: 'pnpm', args: ['dlx', '@modelcontextprotocol/server-memory'] })).toBeNull();
+  });
+
+  test('returns null when URL is missing or non-http', () => {
+    expect(parseMcpRemote({ command: 'npx', args: ['-y', 'mcp-remote'] })).toBeNull();
+    expect(parseMcpRemote({ command: 'npx', args: ['-y', 'mcp-remote', 'not-a-url'] })).toBeNull();
+  });
+
+  test('returns null bearer when no --header is present (still resolves URL)', () => {
+    const result = parseMcpRemote({
+      command: 'npx',
+      args: ['-y', 'mcp-remote', 'https://anonymous.test/mcp'],
+    });
+    expect(result).toEqual({ url: 'https://anonymous.test/mcp', bearer: null });
+  });
+});
+
+describe('selectRequiredRemotes', () => {
+  const remoteA = {
+    command: 'npx',
+    args: ['-y', 'mcp-remote', 'https://a.test/mcp', '--header', 'Authorization:Bearer t1'],
+  };
+  const remoteB = {
+    command: 'npx',
+    args: ['-y', 'mcp-remote', 'https://b.test/mcp'],
+  };
+  const localBuiltin = {
+    command: 'bun',
+    args: ['run', '/app/mcp-tools/index.ts'],
+  };
+
+  test('mcp-remote servers are required by default', () => {
+    const result = selectRequiredRemotes({ a: remoteA, b: remoteB });
+    expect(result.map((r) => r.name).sort()).toEqual(['a', 'b']);
+  });
+
+  test('local stdio MCPs are not probed (no parsed URL)', () => {
+    const result = selectRequiredRemotes({ nanoclaw: localBuiltin });
+    expect(result).toHaveLength(0);
+  });
+
+  test('explicit required:false opts a remote out', () => {
+    const result = selectRequiredRemotes({
+      a: remoteA,
+      b: { ...remoteB, required: false },
+    });
+    expect(result.map((r) => r.name)).toEqual(['a']);
+  });
+
+  test('mixed config: required remotes + opted-out + local', () => {
+    const result = selectRequiredRemotes({
+      'roo-state-manager': remoteA,
+      'optional-thing': { ...remoteB, required: false },
+      nanoclaw: localBuiltin,
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('roo-state-manager');
+  });
+});

--- a/container/agent-runner/src/mcp-health.ts
+++ b/container/agent-runner/src/mcp-health.ts
@@ -1,0 +1,175 @@
+/**
+ * Health check for required MCP servers (fail-fast policy).
+ *
+ * "Required" means the agent cannot honestly serve a turn without it. If a
+ * required MCP is unreachable we halt the container (boot-time) or block the
+ * turn (per-turn) and surface an explicit message — rather than continuing
+ * silently while tool calls to that server fail and the agent routes around
+ * them. Silent partial-degraded operation was the failure mode that triggered
+ * this code: a 404 on roo-state-manager was masked by sk-agent still working,
+ * and the agent kept replying as if everything was fine.
+ *
+ * Only `mcp-remote` servers (HTTP-backed) are health-checked. Local stdio
+ * MCPs (`bun run`, `npx <local-pkg>`) are assumed up because they crash at
+ * spawn rather than misbehave. A server can opt out with `required: false`
+ * in container.json; conversely a non-mcp-remote can opt in with
+ * `required: true` (currently noop — we don't have a probe for stdio).
+ */
+
+interface McpServerConfig {
+  command: string;
+  args: string[];
+  env?: Record<string, string>;
+}
+
+export interface ParsedMcpRemote {
+  url: string;
+  bearer: string | null;
+}
+
+/**
+ * Detect mcp-remote servers and extract their URL + bearer token. Returns
+ * null for non-mcp-remote configs.
+ *
+ * Accepts both `npx -y mcp-remote <url> ...` and `npx mcp-remote <url> ...`.
+ * Bearer is read from `--header Authorization:Bearer <token>` (the canonical
+ * form used in container.json — single arg with colon, no space). Also
+ * tolerates a space after `Authorization:` for hand-written variants.
+ */
+export function parseMcpRemote(cfg: McpServerConfig): ParsedMcpRemote | null {
+  const args = cfg.args ?? [];
+  const mcpRemoteIdx = args.findIndex((a) => a === 'mcp-remote' || a.endsWith('/mcp-remote'));
+  if (mcpRemoteIdx < 0) return null;
+
+  const url = args[mcpRemoteIdx + 1];
+  if (!url || !/^https?:\/\//.test(url)) return null;
+
+  let bearer: string | null = null;
+  for (let i = 0; i < args.length - 1; i++) {
+    if (args[i] !== '--header') continue;
+    const m = args[i + 1].match(/Authorization\s*:\s*Bearer\s+(.+)/i);
+    if (m) {
+      bearer = m[1].trim();
+      break;
+    }
+  }
+  return { url, bearer };
+}
+
+export interface HealthResult {
+  ok: boolean;
+  status?: number;
+  error?: string;
+}
+
+/**
+ * POST initialize to verify the endpoint is alive AND speaking JSON-RPC.
+ * Returns ok=true only when HTTP 200 AND the body looks like a successful
+ * initialize response (mentions `serverInfo` / `result` / `protocolVersion`).
+ *
+ * Timeout default 8s — long enough for IIS ARR + TBXark + sparfenyuk +
+ * upstream stdio handshake on a cold proxy, short enough to fail-fast.
+ */
+export async function probeMcpRemote(parsed: ParsedMcpRemote, timeoutMs = 8000): Promise<HealthResult> {
+  const body = JSON.stringify({
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'nanoclaw-health', version: '1.0' },
+    },
+  });
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    Accept: 'application/json, text/event-stream',
+  };
+  if (parsed.bearer) headers.Authorization = `Bearer ${parsed.bearer}`;
+
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), timeoutMs);
+
+  try {
+    const res = await fetch(parsed.url, { method: 'POST', headers, body, signal: ac.signal });
+    if (res.status !== 200) {
+      let snippet = '';
+      try {
+        snippet = (await res.text()).slice(0, 200);
+      } catch {
+        /* ignore */
+      }
+      return { ok: false, status: res.status, error: `HTTP ${res.status}${snippet ? `: ${snippet}` : ''}` };
+    }
+    const text = await res.text();
+    if (!/serverInfo|protocolVersion|"result"/.test(text)) {
+      return { ok: false, status: 200, error: `unexpected body: ${text.slice(0, 160)}` };
+    }
+    return { ok: true, status: 200 };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: msg };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export interface RequiredRemote {
+  name: string;
+  parsed: ParsedMcpRemote;
+}
+
+/**
+ * Resolve which servers are required AND are mcp-remote (probeable).
+ * - `required: false` → skipped explicitly.
+ * - mcp-remote with no `required` field → required by default. The remote
+ *   chain is the common failure mode; fail fast unless opted out.
+ * - non-mcp-remote → never returned (no probe available).
+ */
+export function selectRequiredRemotes(
+  mcpServers: Record<string, McpServerConfig & { required?: boolean }>,
+): RequiredRemote[] {
+  const out: RequiredRemote[] = [];
+  for (const [name, cfg] of Object.entries(mcpServers)) {
+    if ((cfg as { required?: boolean }).required === false) continue;
+    const parsed = parseMcpRemote(cfg);
+    if (parsed) out.push({ name, parsed });
+  }
+  return out;
+}
+
+interface CacheEntry {
+  result: HealthResult;
+  expiresAt: number;
+}
+const cache = new Map<string, CacheEntry>();
+
+/**
+ * Probe with an in-memory TTL cache so the per-turn check doesn't hammer the
+ * proxy on every batch. Keyed by URL — token rotation is rare and a stale
+ * "ok" cache entry would only mask a freshly-broken auth, which the next
+ * tool call would surface anyway.
+ */
+export async function probeMcpRemoteCached(
+  parsed: ParsedMcpRemote,
+  ttlMs = 60_000,
+): Promise<HealthResult> {
+  const now = Date.now();
+  const hit = cache.get(parsed.url);
+  if (hit && hit.expiresAt > now) return hit.result;
+  const result = await probeMcpRemote(parsed);
+  cache.set(parsed.url, { result, expiresAt: now + ttlMs });
+  return result;
+}
+
+export function clearHealthCache(): void {
+  cache.clear();
+}
+
+/** Format a list of failed health results into a single line for messages/logs. */
+export function formatFailures(failed: { name: string; result: HealthResult }[]): string {
+  return failed
+    .map((f) => `${f.name} (${f.result.error || `HTTP ${f.result.status}`})`)
+    .join('; ');
+}

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -9,6 +9,7 @@ import {
   setContinuation,
 } from './db/session-state.js';
 import { formatMessages, extractRouting, categorizeMessage, isClearCommand, stripInternalTags, type RoutingContext } from './formatter.js';
+import { formatFailures, probeMcpRemoteCached, type RequiredRemote } from './mcp-health.js';
 import type { AgentProvider, AgentQuery, ProviderEvent } from './providers/types.js';
 
 const POLL_INTERVAL_MS = 1000;
@@ -34,6 +35,12 @@ export interface PollLoopConfig {
   systemContext?: {
     instructions?: string;
   };
+  /**
+   * MCP remotes that must be reachable before each turn. If any are down,
+   * the turn is blocked with an explicit 🛑 message (no silent partial
+   * operation). Cached 60s to avoid hammering the proxy.
+   */
+  requiredRemotes?: RequiredRemote[];
 }
 
 /**
@@ -171,6 +178,40 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
     if (keep.length === 0) {
       log(`All ${normalMessages.length} non-command message(s) gated by script, skipping query`);
       continue;
+    }
+
+    // Per-turn fail-fast: refuse to call the provider when a required MCP
+    // remote is down. Better to surface an explicit 🛑 than to let the
+    // agent reply with sk-agent still working while roo-state-manager 404s
+    // — partial degraded operation is the failure mode this guards against.
+    // Cached 60s in mcp-health so this isn't a per-batch hot path.
+    if (config.requiredRemotes && config.requiredRemotes.length > 0) {
+      const healthResults = await Promise.all(
+        config.requiredRemotes.map(async (r) => ({
+          name: r.name,
+          result: await probeMcpRemoteCached(r.parsed),
+        })),
+      );
+      const failed = healthResults.filter((h) => !h.result.ok);
+      if (failed.length > 0) {
+        const failList = formatFailures(failed);
+        log(`BLOCKED: required MCP remote(s) DOWN — ${failList}`);
+        const blockedIds = keep.map((m) => m.id);
+        if (routing.platformId && routing.channelType) {
+          writeMessageOut({
+            id: generateId(),
+            kind: 'chat',
+            platform_id: routing.platformId,
+            channel_type: routing.channelType,
+            thread_id: routing.threadId,
+            content: JSON.stringify({
+              text: `🛑 BLOCKED: required MCP server(s) unreachable: ${failList}\n\nNot processing this message — repair in progress, retry after the chain recovers.`,
+            }),
+          });
+        }
+        markCompleted(blockedIds);
+        continue;
+      }
     }
 
     // Format messages: passthrough commands get raw text (only if the

--- a/src/container-config.ts
+++ b/src/container-config.ts
@@ -22,6 +22,12 @@ export interface McpServerConfig {
   // content to `.claude-fragments/mcp-<name>.md` at spawn and imports it
   // into the composed CLAUDE.md.
   instructions?: string;
+  // Fail-fast policy for mcp-remote servers. Default: an mcp-remote
+  // server is required (probed at boot + every turn; if unreachable the
+  // container halts / the turn is blocked). Set to false to opt out — the
+  // server stays wired but its absence won't stop the agent. See
+  // container/agent-runner/src/mcp-health.ts.
+  required?: boolean;
 }
 
 export interface AdditionalMountConfig {


### PR DESCRIPTION
## Summary

The agent kept replying "normally" when one of its required MCP servers returned 404 — sk-agent still working masked roo-state-manager being unreachable, and tool calls to the dead server quietly failed turn after turn. This PR enforces a fail-fast policy so partial-degraded operation can no longer hide.

## What changed

- **New `container/agent-runner/src/mcp-health.ts`** — parses mcp-remote configs (URL + bearer), POSTs JSON-RPC `initialize` to verify the endpoint, with a 60s in-memory cache.
- **Boot-time check** in `index.ts` — every required mcp-remote is probed before the poll loop starts. Any failure surfaces an explicit message to the first configured destination and exits 1; the host respawns and retries.
- **Per-turn check** in `poll-loop.ts` — same probe (cached) before each batch. On failure, replies with a `🛑 BLOCKED` message naming the unreachable server(s) and skips the turn rather than letting the agent route around the dead tool.
- **`required: false`** in `container.json` opts a server out (mcp-remote servers default to required; local stdio MCPs are not probed).

## Triggering incident

On 2026-04-29 the bot reported `mcp-tools.myia.io` returned 404 on `roo-state-manager` while sk-agent kept working. Sparfenyuk had a stale upstream session that `docker restart myia-mcp-proxy` alone could not clear (4 watchdog attempts in 16 min, all failed). The container kept serving turns without admitting the chain was down. A separate watchdog patch lives in `roo-extensions` (escalation: full-chain restart when tbxark-restart alone is insufficient).

## Test plan

- [x] `bun test` (69 pass / 0 fail), including 10 new tests in `mcp-health.test.ts`
- [x] `bun run typecheck` exit 0
- [x] Host-side `pnpm exec tsc --noEmit` exit 0
- [x] Container image rebuilt; active container stopped to force pickup of new code on next session
- [ ] Verify boot-time check halts cleanly with chain down (manual: cut the proxy, send a message, expect 🛑 alert + container exit)
- [ ] Verify per-turn check blocks a turn with chain down (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)