### PR TITLE
fix(v2): prevent claim-stuck respawn loop on container boot

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -26,6 +26,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 
 import { loadConfig } from './config.js';
+import { clearStaleProcessingAcks, touchHeartbeat } from './db/connection.js';
 import { writeMessageOut } from './db/messages-out.js';
 import { buildSystemPromptAddendum, getAllDestinations } from './destinations.js';
 import { formatFailures, probeMcpRemote, selectRequiredRemotes, type RequiredRemote } from './mcp-health.js';
@@ -42,6 +43,20 @@ function log(msg: string): void {
 const CWD = '/workspace/agent';
 
 async function main(): Promise<void> {
+  // Signal liveness + clear orphan claims BEFORE anything that can block (MCP
+  // health probes, config IO). The host sweep kills containers whose claim
+  // age exceeds tolerance with no fresher heartbeat — if we delay these two
+  // calls, a pre-existing stale `processing_ack` row from a previously
+  // crashed container can race the boot path and the host kills us before
+  // we ever clean it. Symptom: tight kill/respawn loop, claimAge grows
+  // monotonically across boots. Both calls are cheap and idempotent.
+  touchHeartbeat();
+  try {
+    clearStaleProcessingAcks();
+  } catch (err) {
+    log(`Failed to clear stale processing acks at boot: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
   const config = loadConfig();
   const providerName = config.provider.toLowerCase() as ProviderName;
 

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -49,7 +49,7 @@ import type { AgentGroup, Session } from './types.js';
 const onecli = new OneCLI({ url: ONECLI_URL, apiKey: ONECLI_API_KEY });
 
 /** Active containers tracked by session ID. */
-const activeContainers = new Map<string, { process: ChildProcess; containerName: string }>();
+const activeContainers = new Map<string, { process: ChildProcess; containerName: string; spawnedAt: number }>();
 
 /**
  * In-flight wake promises, keyed by session id. Deduplicates concurrent
@@ -67,6 +67,21 @@ export function getActiveContainerCount(): number {
 
 export function isContainerRunning(sessionId: string): boolean {
   return activeContainers.has(sessionId);
+}
+
+/**
+ * When was the active container for this session spawned (epoch ms)?
+ * Returns null if no container is currently tracked for the session.
+ *
+ * Used by host-sweep to apply a startup grace window before evaluating
+ * claim-stuck rules — a freshly-spawned container needs a few seconds to
+ * touch its heartbeat file and clear orphan processing_ack rows from a
+ * previously crashed container. Without this, a stale claim from a prior
+ * crash would loop the new container into kill/respawn before it ever ran
+ * a single line of JS.
+ */
+export function getContainerSpawnedAt(sessionId: string): number | null {
+  return activeContainers.get(sessionId)?.spawnedAt ?? null;
 }
 
 /**
@@ -160,7 +175,7 @@ async function spawnContainer(session: Session): Promise<void> {
 
   const container = spawn(CONTAINER_RUNTIME_BIN, args, { stdio: ['ignore', 'pipe', 'pipe'] });
 
-  activeContainers.set(session.id, { process: container, containerName });
+  activeContainers.set(session.id, { process: container, containerName, spawnedAt: Date.now() });
   markContainerRunning(session.id);
 
   // Log stderr

--- a/src/host-sweep.test.ts
+++ b/src/host-sweep.test.ts
@@ -5,7 +5,7 @@
  */
 import { describe, expect, it } from 'vitest';
 
-import { ABSOLUTE_CEILING_MS, CLAIM_STUCK_MS, decideStuckAction } from './host-sweep.js';
+import { ABSOLUTE_CEILING_MS, CLAIM_STUCK_MS, STARTUP_GRACE_MS, decideStuckAction } from './host-sweep.js';
 
 const BASE = Date.parse('2026-04-20T12:00:00.000Z');
 
@@ -132,6 +132,35 @@ describe('decideStuckAction', () => {
       claims: [claim('msg-1', 5 * 60 * 1000)],
     });
     expect(res.action).toBe('ok');
+  });
+
+  it('suppresses claim-stuck during the startup grace window for a freshly-spawned container', () => {
+    // Reproduces the "infinite kill/respawn loop" bug: a previous container
+    // crashed leaving a 'processing' row in outbound.db. The replacement is
+    // spawned, but the host sweep evaluates claim-stuck before the new
+    // container can run its boot-time DELETE. Without the grace, the new
+    // container is killed within ms of spawn and the loop repeats forever.
+    const veryOldClaimMs = CLAIM_STUCK_MS + 60 * 60 * 1000; // claim from 1h+ ago
+    const res = decideStuckAction({
+      now: BASE,
+      heartbeatMtimeMs: 0, // fresh container hasn't ticked yet
+      containerState: null,
+      claims: [claim('msg-old', veryOldClaimMs)],
+      spawnedAtMs: BASE - 5_000, // spawned 5s ago, well within grace
+    });
+    expect(res.action).toBe('ok');
+  });
+
+  it('still kills claim-stuck once the startup grace window has elapsed', () => {
+    const veryOldClaimMs = CLAIM_STUCK_MS + 60 * 60 * 1000;
+    const res = decideStuckAction({
+      now: BASE,
+      heartbeatMtimeMs: 0,
+      containerState: null,
+      claims: [claim('msg-old', veryOldClaimMs)],
+      spawnedAtMs: BASE - STARTUP_GRACE_MS - 5_000, // grace expired
+    });
+    expect(res.action).toBe('kill-claim');
   });
 
   it('ignores claims with unparseable timestamps', () => {

--- a/src/host-sweep.ts
+++ b/src/host-sweep.ts
@@ -43,7 +43,7 @@ import {
 } from './db/session-db.js';
 import { log } from './log.js';
 import { openInboundDb, openOutboundDb, inboundDbPath, heartbeatPath } from './session-manager.js';
-import { isContainerRunning, killContainer, wakeContainer } from './container-runner.js';
+import { getContainerSpawnedAt, isContainerRunning, killContainer, wakeContainer } from './container-runner.js';
 import type { Session } from './types.js';
 
 const SWEEP_INTERVAL_MS = 60_000;
@@ -54,6 +54,13 @@ export const ABSOLUTE_CEILING_MS = 30 * 60 * 1000;
 // Stuck tolerance window applied per 'processing' claim — "did we see any
 // signs of life since this message was claimed?"
 export const CLAIM_STUCK_MS = 60 * 1000;
+// Grace window after a container spawn during which we suppress the
+// claim-stuck rule. A fresh container needs a moment to import modules,
+// touch its heartbeat, and DELETE orphan `processing_ack` rows left by a
+// previously crashed container. Without this, a single old claim would
+// loop spawn → kill → respawn forever — the new container never gets to
+// run the cleanup line.
+export const STARTUP_GRACE_MS = 30 * 1000;
 const MAX_TRIES = 5;
 const BACKOFF_BASE_MS = 5000;
 
@@ -72,8 +79,15 @@ export function decideStuckAction(args: {
   heartbeatMtimeMs: number; // 0 when heartbeat file absent
   containerState: ContainerState | null;
   claims: Array<{ message_id: string; status_changed: string }>;
+  /**
+   * Epoch ms when the current container was spawned. Used to suppress the
+   * claim-stuck rule during the startup grace window — a fresh container
+   * needs a moment to clear orphan claims left by a previously crashed
+   * peer. null when the host doesn't track a spawn time (e.g. tests).
+   */
+  spawnedAtMs?: number | null;
 }): StuckDecision {
-  const { now, heartbeatMtimeMs, containerState, claims } = args;
+  const { now, heartbeatMtimeMs, containerState, claims, spawnedAtMs } = args;
   const declaredToolMs = declaredToolTimeoutMs(containerState);
 
   // Ceiling check only applies when we have an actual heartbeat timestamp.
@@ -90,6 +104,15 @@ export function decideStuckAction(args: {
     if (heartbeatAge > ceiling) {
       return { action: 'kill-ceiling', heartbeatAgeMs: heartbeatAge, ceilingMs: ceiling };
     }
+  }
+
+  // Startup grace: while a freshly-spawned container is still importing
+  // modules and clearing orphan processing_ack rows, suppress claim-stuck.
+  // Without this, a stale claim left by a crashed predecessor produces an
+  // infinite kill/respawn loop because the replacement is killed before its
+  // first line of JS runs.
+  if (spawnedAtMs != null && now - spawnedAtMs < STARTUP_GRACE_MS) {
+    return { action: 'ok' };
   }
 
   const tolerance = Math.max(CLAIM_STUCK_MS, declaredToolMs ?? 0);
@@ -222,6 +245,7 @@ function enforceRunningContainerSla(
     heartbeatMtimeMs: heartbeatMtimeMs(agentGroupId, session.id),
     containerState: getContainerState(outDb),
     claims: getProcessingClaims(outDb),
+    spawnedAtMs: getContainerSpawnedAt(session.id),
   });
 
   if (decision.action === 'ok') return;


### PR DESCRIPTION
## Summary

Three coordinated changes that fix the kill/respawn loop incident:

- **container/agent-runner/src/index.ts**: touch heartbeat + clear stale `processing_ack` rows at the very top of `main()`, before MCP probes
- **src/container-runner.ts**: track `spawnedAt` per session, expose `getContainerSpawnedAt()`
- **src/host-sweep.ts**: add `STARTUP_GRACE_MS = 30s` — within that window the claim-stuck rule is suppressed so the new container can finish booting and run its own cleanup

## Why this was needed

After a host crash leaves a stale `processing_ack` row, a freshly spawned container would block on MCP probes for ~10s during boot, giving host-sweep enough time to see the orphan claim and kill the new container before it could clear the row — looping forever (~1 spawn/sec).

## Test plan

- [x] 12/12 host-sweep tests pass (2 new reproducing the bug — would loop forever without the grace window)
- [x] `pnpm exec tsc --noEmit` clean
- [x] `bun run typecheck` clean (container)
- [ ] Smoke run: kill container manually, verify respawn succeeds within first sweep tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)