### PR TITLE
fix(v2/data): clear malformed cron + expire stale approvals + UTF-8 watcher logs

### DIFF
--- a/scripts/service/start-roosync-watcher.ps1
+++ b/scripts/service/start-roosync-watcher.ps1
@@ -34,11 +34,13 @@ if (Test-Path $EnvFile) {
         }
         [Environment]::SetEnvironmentVariable($name, $value, 'Process')
     }
-    "[start-roosync-watcher] Loaded .env from $EnvFile" | Tee-Object -FilePath $LogFile -Append
+    "[start-roosync-watcher] Loaded .env from $EnvFile" | Out-File -FilePath $LogFile -Append -Encoding utf8
 } else {
-    "[start-roosync-watcher] WARNING: .env not found at $EnvFile" | Tee-Object -FilePath $LogFile -Append
+    "[start-roosync-watcher] WARNING: .env not found at $EnvFile" | Out-File -FilePath $LogFile -Append -Encoding utf8
 }
 
-# Launch standalone watcher, appending to the log
-"[start-roosync-watcher] Starting node $EntryPoint (pid $PID)" | Tee-Object -FilePath $LogFile -Append
-& node $EntryPoint *>> $LogFile
+# Launch standalone watcher. Redirecting via Out-File -Encoding utf8 because
+# PowerShell 5.1's `*>>` defaults to Default encoding (UTF-16LE on FR locale),
+# which makes the resulting log file unreadable to grep/tail/awk.
+"[start-roosync-watcher] Starting node $EntryPoint (pid $PID)" | Out-File -FilePath $LogFile -Append -Encoding utf8
+& node $EntryPoint 2>&1 | Out-File -FilePath $LogFile -Append -Encoding utf8

--- a/src/db/sessions.ts
+++ b/src/db/sessions.ts
@@ -193,6 +193,24 @@ export function getPendingApprovalsByAction(action: string): PendingApproval[] {
 }
 
 /**
+ * Mark every still-pending approval whose `expires_at` is in the past as
+ * `'expired'` and return the affected rows. Caller is responsible for
+ * notifying the requesting session — keeping the DB op pure makes it easy
+ * to test and re-use.
+ */
+export function expireStalePendingApprovals(nowIso: string): PendingApproval[] {
+  const db = getDb();
+  const stale = db
+    .prepare("SELECT * FROM pending_approvals WHERE status = 'pending' AND expires_at IS NOT NULL AND expires_at < ?")
+    .all(nowIso) as PendingApproval[];
+  if (stale.length === 0) return [];
+  db.prepare(
+    "UPDATE pending_approvals SET status = 'expired' WHERE status = 'pending' AND expires_at IS NOT NULL AND expires_at < ?",
+  ).run(nowIso);
+  return stale;
+}
+
+/**
  * Resolve ask_question render metadata (title + normalized options) for any
  * card, regardless of whether it was persisted as a pending_question (generic
  * ask_user_question) or a pending_approval (self-mod / OneCLI credential).

--- a/src/host-sweep.ts
+++ b/src/host-sweep.ts
@@ -121,6 +121,12 @@ async function sweep(): Promise<void> {
   if (!running) return;
 
   try {
+    await expireApprovalsTick();
+  } catch (err) {
+    log.error('Approval expiry tick error', { err });
+  }
+
+  try {
     const sessions = getActiveSessions();
     for (const session of sessions) {
       await sweepSession(session);
@@ -130,6 +136,30 @@ async function sweep(): Promise<void> {
   }
 
   setTimeout(sweep, SWEEP_INTERVAL_MS);
+}
+
+async function expireApprovalsTick(): Promise<void> {
+  const { expireStalePendingApprovals } = await import('./db/sessions.js');
+  const expired = expireStalePendingApprovals(new Date().toISOString());
+  if (expired.length === 0) return;
+
+  // Notify each requesting session so the agent learns its approval ran out
+  // instead of silently waiting forever. Best-effort — errors per row don't
+  // stop the others.
+  const { notifyAgent } = await import('./modules/approvals/primitive.js');
+  const { getSession } = await import('./db/sessions.js');
+  for (const a of expired) {
+    log.warn('Approval expired without response', { approvalId: a.approval_id, action: a.action });
+    if (!a.session_id) continue;
+    try {
+      const session = getSession(a.session_id);
+      if (session) {
+        notifyAgent(session, `Approval request expired without response (action=${a.action}).`);
+      }
+    } catch (err) {
+      log.error('Failed to notify agent of expired approval', { approvalId: a.approval_id, err });
+    }
+  }
 }
 
 async function sweepSession(session: Session): Promise<void> {

--- a/src/modules/approvals/primitive.ts
+++ b/src/modules/approvals/primitive.ts
@@ -38,6 +38,9 @@ const APPROVAL_OPTIONS: RawOption[] = [
   { label: 'Reject', selectedLabel: '❌ Rejected', value: 'reject' },
 ];
 
+/** Default lifetime for an approval request. Sweep marks anything older expired. */
+export const APPROVAL_DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
+
 // ── Approval handler registry ──
 // Modules that want to be called back when an admin approves a pending row
 // register here at import time, keyed by the `action` string they used in
@@ -182,13 +185,15 @@ export async function requestApproval(opts: RequestApprovalOptions): Promise<voi
 
   const approvalId = `appr-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   const normalizedOptions = normalizeOptions(APPROVAL_OPTIONS);
+  const now = Date.now();
   createPendingApproval({
     approval_id: approvalId,
     session_id: session.id,
     request_id: approvalId,
     action,
     payload: JSON.stringify(payload),
-    created_at: new Date().toISOString(),
+    created_at: new Date(now).toISOString(),
+    expires_at: new Date(now + APPROVAL_DEFAULT_TTL_MS).toISOString(),
     title,
     options_json: JSON.stringify(normalizedOptions),
   });

--- a/src/modules/scheduling/recurrence.test.ts
+++ b/src/modules/scheduling/recurrence.test.ts
@@ -7,6 +7,7 @@
  * user-local — a recurring scheduling bug users can't diagnose.
  */
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import { afterEach, describe, expect, it } from 'vitest';
 
@@ -15,14 +16,27 @@ import { insertTask } from './db.js';
 import { handleRecurrence } from './recurrence.js';
 import type { Session } from '../../types.js';
 
-const TEST_DIR = '/tmp/nanoclaw-recurrence-test';
+// Per-process tmp dir avoids EPERM under Windows when sibling test files hold
+// open handles to the shared `/tmp/nanoclaw-recurrence-test` location.
+const TEST_DIR = path.join(os.tmpdir(), `nanoclaw-recurrence-test-${process.pid}`);
 const DB_PATH = path.join(TEST_DIR, 'inbound.db');
 
+let openDb: ReturnType<typeof openInboundDb> | null = null;
+
 function freshDb() {
-  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+  if (openDb) {
+    try {
+      openDb.close();
+    } catch {
+      // already closed
+    }
+    openDb = null;
+  }
+  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true, force: true });
   fs.mkdirSync(TEST_DIR, { recursive: true });
   ensureSchema(DB_PATH, 'inbound');
-  return openInboundDb(DB_PATH);
+  openDb = openInboundDb(DB_PATH);
+  return openDb;
 }
 
 function fakeSession(): Session {
@@ -39,7 +53,15 @@ function fakeSession(): Session {
 }
 
 afterEach(() => {
-  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+  if (openDb) {
+    try {
+      openDb.close();
+    } catch {
+      // already closed
+    }
+    openDb = null;
+  }
+  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true, force: true });
 });
 
 describe('handleRecurrence', () => {
@@ -75,6 +97,38 @@ describe('handleRecurrence', () => {
     expect(follow.recurrence).toBe('0 9 * * *');
     expect(follow.series_id).toBe('task-1');
     expect(new Date(follow.process_after).getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it('clears recurrence when cron expression is malformed (no infinite re-error)', async () => {
+    const db = freshDb();
+    insertTask(db, {
+      id: 'task-bad',
+      processAfter: '2020-01-01T00:00:00.000Z',
+      // Invalid: cron-parser rejects ranges where min > max ("21-5" should be
+      // split into "21-23,0-5"). Real-world reproducer from Apr 30 incident.
+      recurrence: '0 21-5 * * *',
+      platformId: null,
+      channelType: null,
+      threadId: null,
+      content: JSON.stringify({ prompt: 'night shift' }),
+    });
+    db.prepare(`UPDATE messages_in SET status='completed' WHERE id='task-bad'`).run();
+
+    await handleRecurrence(db, fakeSession());
+
+    const row = db
+      .prepare(`SELECT id, status, recurrence FROM messages_in WHERE id='task-bad'`)
+      .get() as { id: string; status: string; recurrence: string | null };
+    // Recurrence cleared so the next tick won't pick this row up again.
+    expect(row.recurrence).toBeNull();
+    // No follow-up row created — recurrence was unparseable.
+    const count = (db.prepare(`SELECT COUNT(*) AS c FROM messages_in`).get() as { c: number }).c;
+    expect(count).toBe(1);
+
+    // Idempotent: a second tick should be a no-op.
+    await handleRecurrence(db, fakeSession());
+    const countAfter = (db.prepare(`SELECT COUNT(*) AS c FROM messages_in`).get() as { c: number }).c;
+    expect(countAfter).toBe(1);
   });
 
   it('does not clone rows whose recurrence is already cleared', async () => {

--- a/src/modules/scheduling/recurrence.test.ts
+++ b/src/modules/scheduling/recurrence.test.ts
@@ -116,9 +116,11 @@ describe('handleRecurrence', () => {
 
     await handleRecurrence(db, fakeSession());
 
-    const row = db
-      .prepare(`SELECT id, status, recurrence FROM messages_in WHERE id='task-bad'`)
-      .get() as { id: string; status: string; recurrence: string | null };
+    const row = db.prepare(`SELECT id, status, recurrence FROM messages_in WHERE id='task-bad'`).get() as {
+      id: string;
+      status: string;
+      recurrence: string | null;
+    };
     // Recurrence cleared so the next tick won't pick this row up again.
     expect(row.recurrence).toBeNull();
     // No follow-up row created — recurrence was unparseable.

--- a/src/modules/scheduling/recurrence.ts
+++ b/src/modules/scheduling/recurrence.ts
@@ -44,7 +44,19 @@ export async function handleRecurrence(inDb: Database.Database, session: Session
         sessionId: session.id,
       });
     } catch (err) {
-      log.error('Failed to compute next recurrence', {
+      // Cron string can't fix itself — clearing recurrence stops every-tick spam
+      // and lets the agent see the failure once instead of repeatedly. Discovered
+      // after a "0 21-5 * * *" task (invalid range, min>max) re-threw every minute
+      // for ~16h, blocking the night shift entirely.
+      try {
+        clearRecurrence(inDb, msg.id);
+      } catch (clearErr) {
+        log.error('Failed to clear malformed recurrence after parse error', {
+          messageId: msg.id,
+          err: clearErr,
+        });
+      }
+      log.error('Cleared malformed recurrence after parse failure', {
         messageId: msg.id,
         recurrence: msg.recurrence,
         err,


### PR DESCRIPTION
## Summary

Three orthogonal data-side fixes uncovered while diagnosing a 6-hour night-shift outage on Apr 30 → May 1.

### 1. Invalid cron defense (root cause of the outage)

A scheduled task with cron `0 21-5 * * *` was created on Apr 30 (range min>max, invalid — should be `0 21-23,0-5 * * *`). Once the row hit `status='completed'`, every sweep tick re-tried `cron-parser.parse()`, threw the same error, logged it, and never advanced. Three such night tasks ran ~16h straight emitting one ERROR per task per minute — and the night shift was completely silent because no recurrence was ever scheduled forward.

Fix in `src/modules/scheduling/recurrence.ts`: on parse failure, also call `clearRecurrence()`. The agent gets a single error log it can react to instead of an infinite loop. New test reproduces the bug + verifies idempotency.

### 2. Approval expiry

`pending_approvals.expires_at` was schemed but never populated. Approvals could sit pending indefinitely if the approver never replied (one zombie row was found from Mar 20).

- `src/modules/approvals/primitive.ts` — populate `expires_at = now + 24h` at request time
- `src/db/sessions.ts` — new `expireStalePendingApprovals(nowIso)` helper
- `src/host-sweep.ts` — new `expireApprovalsTick()` runs once per sweep before the per-session loop, marks expired rows, notifies the requesting agent

### 3. UTF-8 watcher logs

`scripts/service/start-roosync-watcher.ps1` used `*>>` and `Tee-Object -Append`, both of which use PowerShell 5.1's Default encoding (= UTF-16LE on FR locale). Result: `logs/roosync-inbox-standalone.log` was UTF-16 with CRLF — unreadable by grep/tail/awk. Replaced with explicit `Out-File -Encoding utf8 -Append`.

### Plus: stabilize recurrence.test.ts on Windows

The test was sharing `/tmp/nanoclaw-recurrence-test` across runs and leaving DB handles open → consistent EPERM failures on Windows. Switched to per-process tmp dir + closes DB in `afterEach`.

## Test plan

- [x] `pnpm exec vitest run src/modules/scheduling/recurrence.test.ts` — 3/3 pass (was 0/3 due to EPERM)
- [x] `pnpm exec vitest run src/host-sweep.test.ts` — 10/10 pass
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `bun run typecheck` (container) — clean
- [ ] After merge: re-launch the scheduled watcher task, verify `file logs/roosync-inbox-standalone.log` reports UTF-8 ASCII

🤖 Generated with [Claude Code](https://claude.com/claude-code)