### PR TITLE
fix(channels/cli): use named pipe on Windows to stop EACCES boot loop

### DIFF
--- a/scripts/chat.ts
+++ b/scripts/chat.ts
@@ -11,16 +11,11 @@
  * `cli/local` via `/init-first-agent` or `/manage-channels`.
  */
 import net from 'net';
-import path from 'path';
 
-import { DATA_DIR } from '../src/config.js';
+import { getCliSocketPath } from '../src/config.js';
 
 const SILENCE_MS = 2000; // exit after this much quiet time following the first reply
 const TOTAL_TIMEOUT_MS = 120_000; // hard stop
-
-function socketPath(): string {
-  return path.join(DATA_DIR, 'cli.sock');
-}
 
 function main(): void {
   const words = process.argv.slice(2);
@@ -30,12 +25,12 @@ function main(): void {
   }
   const text = words.join(' ');
 
-  const socket = net.connect(socketPath());
+  const socket = net.connect(getCliSocketPath());
 
   socket.on('error', (err) => {
     const e = err as NodeJS.ErrnoException;
     if (e.code === 'ENOENT' || e.code === 'ECONNREFUSED') {
-      console.error(`NanoClaw daemon not reachable at ${socketPath()}.`);
+      console.error(`NanoClaw daemon not reachable at ${getCliSocketPath()}.`);
       console.error('Start the service (launchctl/systemd) before running nc.');
     } else {
       console.error('CLI socket error:', err);

--- a/scripts/init-first-agent.ts
+++ b/scripts/init-first-agent.ts
@@ -33,7 +33,7 @@
 import net from 'net';
 import path from 'path';
 
-import { DATA_DIR } from '../src/config.js';
+import { DATA_DIR, getCliSocketPath } from '../src/config.js';
 import { createAgentGroup, getAgentGroupByFolder } from '../src/db/agent-groups.js';
 import { initDb } from '../src/db/connection.js';
 import {
@@ -320,7 +320,7 @@ async function sendWelcomeViaCliSocket(
   welcome: string,
   identity: { senderId: string; sender: string },
 ): Promise<void> {
-  const sockPath = path.join(DATA_DIR, 'cli.sock');
+  const sockPath = getCliSocketPath();
 
   await new Promise<void>((resolve, reject) => {
     const socket = net.connect(sockPath);

--- a/src/channels/cli.ts
+++ b/src/channels/cli.ts
@@ -1,11 +1,13 @@
 /**
- * CLI channel — talk to your agent from a local terminal via Unix socket.
+ * CLI channel — talk to your agent from a local terminal via Unix socket
+ * (POSIX) or named pipe (Windows).
  *
  * Always-on, zero-credentials channel that ships with main. The daemon
- * listens on `data/cli.sock`; the `scripts/chat.ts` client connects, writes
- * a JSON line per message, reads JSON lines back. The channel plumbs into
- * the normal router/delivery path like any other adapter — `/clear` and
- * other session-level commands work identically.
+ * listens on `data/cli.sock` on POSIX or `\\.\pipe\nanoclaw-cli` on Windows;
+ * the `scripts/chat.ts` client connects, writes a JSON line per message,
+ * reads JSON lines back. The channel plumbs into the normal router/delivery
+ * path like any other adapter — `/clear` and other session-level commands
+ * work identically.
  *
  * Wire format: one JSON object per line.
  *
@@ -35,18 +37,14 @@
  */
 import fs from 'fs';
 import net from 'net';
-import path from 'path';
 
-import { DATA_DIR } from '../config.js';
+import { getCliSocketPath } from '../config.js';
 import { log } from '../log.js';
 import type { ChannelAdapter, ChannelSetup, DeliveryAddress, InboundEvent, OutboundMessage } from './adapter.js';
 import { registerChannelAdapter } from './channel-registry.js';
 
 const PLATFORM_ID = 'local';
-
-function socketPath(): string {
-  return path.join(DATA_DIR, 'cli.sock');
-}
+const IS_WINDOWS = process.platform === 'win32';
 
 function createAdapter(): ChannelAdapter {
   let server: net.Server | null = null;
@@ -58,16 +56,19 @@ function createAdapter(): ChannelAdapter {
     supportsThreads: false,
 
     async setup(config: ChannelSetup): Promise<void> {
-      const sock = socketPath();
+      const sock = getCliSocketPath();
 
-      // Stale socket cleanup: a previous run that crashed may have left the
-      // file behind, and net.createServer refuses to bind to an existing path.
-      try {
-        fs.unlinkSync(sock);
-      } catch (err) {
-        const e = err as NodeJS.ErrnoException;
-        if (e.code !== 'ENOENT') {
-          log.warn('Failed to unlink stale CLI socket (will try to bind anyway)', { sock, err });
+      // Stale socket cleanup (POSIX only — Windows named pipes are auto-cleaned
+      // by the OS when the previous owning process exits, and unlink on a
+      // pipe path returns EPERM).
+      if (!IS_WINDOWS) {
+        try {
+          fs.unlinkSync(sock);
+        } catch (err) {
+          const e = err as NodeJS.ErrnoException;
+          if (e.code !== 'ENOENT') {
+            log.warn('Failed to unlink stale CLI socket (will try to bind anyway)', { sock, err });
+          }
         }
       }
 
@@ -75,13 +76,14 @@ function createAdapter(): ChannelAdapter {
       await new Promise<void>((resolve, reject) => {
         server!.once('error', reject);
         server!.listen(sock, () => {
-          // Tighten perms so only the owner can connect. Unix socket files
-          // obey filesystem perms — 0700 on the socket means other local
-          // users can't send into this agent.
-          try {
-            fs.chmodSync(sock, 0o600);
-          } catch (err) {
-            log.warn('Failed to chmod CLI socket (continuing)', { sock, err });
+          // Tighten perms so only the owner can connect (POSIX only — named
+          // pipe ACLs are enforced by the OS, not chmod).
+          if (!IS_WINDOWS) {
+            try {
+              fs.chmodSync(sock, 0o600);
+            } catch (err) {
+              log.warn('Failed to chmod CLI socket (continuing)', { sock, err });
+            }
           }
           log.info('CLI channel listening', { sock });
           resolve();
@@ -104,11 +106,13 @@ function createAdapter(): ChannelAdapter {
         });
         server = null;
       }
-      // Remove the socket file so a relaunch doesn't trip over it.
-      try {
-        fs.unlinkSync(socketPath());
-      } catch {
-        // swallow
+      // Remove the socket file so a relaunch doesn't trip over it (POSIX only).
+      if (!IS_WINDOWS) {
+        try {
+          fs.unlinkSync(getCliSocketPath());
+        } catch {
+          // swallow
+        }
       }
     },
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -25,6 +25,21 @@ export const STORE_DIR = path.resolve(PROJECT_ROOT, 'store');
 export const GROUPS_DIR = path.resolve(PROJECT_ROOT, 'groups');
 export const DATA_DIR = path.resolve(PROJECT_ROOT, 'data');
 
+/**
+ * CLI channel transport endpoint. On POSIX this is a Unix socket file under
+ * data/; on Windows we use a named pipe instead because Node's AF_UNIX
+ * support on NTFS hits EACCES under the service account (the daemon binds
+ * but cannot chmod, then the next start re-binds and fails). Named pipes
+ * are auto-cleaned by the OS when the owning process exits, so no stale
+ * unlink is needed on Windows.
+ */
+export function getCliSocketPath(): string {
+  if (process.platform === 'win32') {
+    return '\\\\.\\pipe\\nanoclaw-cli';
+  }
+  return path.join(DATA_DIR, 'cli.sock');
+}
+
 // Per-checkout image tag so two installs on the same host don't share
 // `nanoclaw-agent:latest` and clobber each other on rebuild.
 export const CONTAINER_IMAGE_BASE = process.env.CONTAINER_IMAGE_BASE || getContainerImageBase(PROJECT_ROOT);


### PR DESCRIPTION
## Summary

- On Windows, the CLI channel's `data/cli.sock` Unix-socket bind fails with `EACCES` under the NSSM service account. Each boot logs a FATAL adapter-init error that the supervisor retries, polluting `err.log` every restart and contributing to circuit-breaker delays.
- Switch the CLI transport to a Windows named pipe (`\.\pipe\nanoclaw-cli`) on `win32` only — POSIX still uses the existing socket file under `data/`.
- Centralizes the path in `getCliSocketPath()` (src/config.ts); both endpoints (`src/channels/cli.ts` daemon and `scripts/chat.ts` / `scripts/init-first-agent.ts` clients) share it.
- Named pipes are auto-cleaned by Windows on owner-process exit, so the unlink/chmod dance from POSIX is gated behind `IS_WINDOWS`.

## Why now

Observed in `logs/nanoclaw.err.log` after every NSSM restart since the migration to Windows-hosted host: 

```
[ERROR] Failed to start channel adapter channel="cli" 
  err=Error: listen EACCES: permission denied D:\nanoclaw\data\cli.sock
```

Chronic noise was masked behind the bigger circuit-breaker / Docker-not-running incidents but now blocks clean log review.

## Test plan

- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm run build` clean
- [x] `npx vitest run src/channels` — 52/52 pass
- [ ] Post-merge: NSSM restart on D:/nanoclaw → confirm `Failed to start channel adapter channel="cli"` no longer appears in `nanoclaw.err.log`
- [ ] Post-merge: `pnpm run chat hello` from a separate terminal still routes to the live agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)