### PR TITLE
fix(router): use '_' separator in messageIdForAgent to keep ids NTFS-safe

### DIFF
--- a/PATCHES.md
+++ b/PATCHES.md
@@ -130,6 +130,14 @@ If none works, document the patch here with justification.
 - **Exit condition:** Migrate to a container skill `container/skills/voice-transcription/` that the agent invokes (planned in PATCHES.md original entry #9). Once the skill ships, this host-side path can be removed.
 - **Lines:** ~80 (module) + ~20 (channel integration).
 
+### 13. Filesystem-safe per-agent message id separator (`messageIdForAgent`)
+
+- **File:** `src/router.ts` (function `messageIdForAgent` at end of file)
+- **Summary:** Replace `${id}:${agentGroupId}` with `${id}_${agentGroupId}` and strip any remaining `:` from `baseId`. Result: id like `-5256188832_1581_ag-...` instead of `-5256188832:1581:ag-...`.
+- **Why:** Upstream sync `94170b0` (v2.0.13..v2.0.23) introduced this helper with `:` as separator. Telegram's `message.id` is already `${chatId}:${msgId}`, so the result has 2 colons. The id is consumed as a filesystem directory name in `session-manager.ts:extractAttachmentFiles` (line 291). On Windows NTFS, `:` is reserved (drive prefix and alternate data streams), so `mkdirSync(inbox/<id>)` fails with ENOENT, which crashes inbound routing for every voice/attachment message and eventually kills the host process. POSIX hosts (upstream's default test surface) accept `:` in filenames so upstream did not see this regression. `isSafeAttachmentName` doesn't catch it either — it tests for `/`, `\`, NUL, and `path.basename(name) === name`, which all pass on this id.
+- **Exit condition:** Upstream changes `messageIdForAgent` to use a filesystem-safe separator (e.g. `_`) or sanitizes the id before it reaches the inbox path.
+- **Lines:** ~10 (1 expression change + 8 lines of explanatory comment).
+
 ---
 
 ## Deferred / not yet applied

--- a/src/router.ts
+++ b/src/router.ts
@@ -489,8 +489,15 @@ async function deliverToAgent(
  * session DBs. messages_in.id is PRIMARY KEY, so reuse of the raw id would
  * collide across sessions (or, more subtly, within one session if re-routed
  * after a retry). Namespace by agent_group_id to keep ids unique per session.
+ *
+ * Patch (overlay #13, see PATCHES.md): use '_' instead of ':' as separator,
+ * and replace any ':' coming from `baseId`. Telegram's `message.id` is
+ * `${chatId}:${msgId}` already, and the resulting id is consumed as a
+ * filesystem directory name in `session-manager.ts:extractAttachmentFiles`.
+ * On Windows NTFS, ':' is reserved (drive prefix + alternate data streams),
+ * so `mkdirSync(inbox/<id>)` fails with ENOENT and crashes inbound routing.
  */
 function messageIdForAgent(baseId: string | undefined, agentGroupId: string): string {
   const id = baseId && baseId.length > 0 ? baseId : generateId();
-  return `${id}:${agentGroupId}`;
+  return `${id}_${agentGroupId}`.replace(/:/g, '_');
 }


### PR DESCRIPTION
## Summary

- Upstream sync `94170b0` (v2.0.13..v2.0.23) introduced `messageIdForAgent` in `src/router.ts` using `${id}:${agentGroupId}`. For Telegram (whose `message.id` is `${chatId}:${msgId}`), the result has 2 colons (`chatId:msgId:agId`).
- That id is consumed as a directory name in [src/session-manager.ts:291](src/session-manager.ts#L291) (`mkdirSync(inbox/<id>)`). On Windows NTFS `:` is reserved (drive prefix + alternate data streams), so `mkdirSync` fails with ENOENT and the inbound routing path crashes.
- `isSafeAttachmentName` does not catch this — its checks are `/`, `\`, NUL plus `path.basename(name) === name`, all of which pass on this id.

## Production symptoms (this install)

- Every Telegram voice / attachment message after the May 1 sync logged `Failed to route inbound message ENOENT mkdir '...inbox/-CHATID:MSGID:ag-XXX'` and was effectively dropped.
- Around 2026-05-01 19:37Z the host process went silent; NSSM did not auto-recover and the Windows service stayed in zombie state (wrapper present, main `node dist/index.js` gone) for ~3.5h until manual intervention.
- Affected `inbound.db` row: `-5256188832:1481:ag-1776992584813-k3oj0w` (failed=5 tries, never reroutable).

## Fix

In `messageIdForAgent`: use `_` as separator and strip any remaining `:` from the constructed id. The id is opaque (PRIMARY KEY in `messages_in`, never parsed back), so the format change is safe.

POSIX hosts (upstream's default test surface) accept `:` in filenames, which is why upstream did not see the regression.

## Why an overlay patch instead of upstream-first

This is the simplest, surgical fix and the install is in production breakage. Documented as overlay patch #13 in `PATCHES.md`. An upstream-first version would change the same line; happy to forward to upstream after this is in.

## Test plan
- [x] `pnpm run build` clean
- [x] Service restarted on this host (Windows), no new ENOENT errors in `nanoclaw.err.log` since restart
- [ ] Validate next inbound Telegram message produces an id with `_` separator and no mkdir failure (will land in next `[Message routed]` log line)

🤖 Generated with [Claude Code](https://claude.com/claude-code)