### PR TITLE
fix(scheduling): unstick list_tasks on BLOB-tainted rows

### DIFF
--- a/container/agent-runner/src/mcp-tools/scheduling.ts
+++ b/container/agent-runner/src/mcp-tools/scheduling.ts
@@ -149,9 +149,20 @@ export const listTasks: McpToolDefinition = {
 
     if ((rows as unknown[]).length === 0) return ok('No tasks found.');
 
-    const lines = (rows as Array<{ id: string; status: string; process_after: string | null; recurrence: string | null; content: string }>).map((r) => {
-      const content = JSON.parse(r.content);
-      const prompt = (content.prompt as string || '').slice(0, 80);
+    // bun:sqlite returns BLOB-typed columns as Uint8Array even when the column
+    // has TEXT affinity (manifest typing — type is per-row). A historical taint
+    // can leave a row stored as BLOB; JSON.parse(Uint8Array) throws in Bun.
+    // Coerce defensively, and never let one bad row sink the whole listing —
+    // otherwise the agent loses access to pause/cancel any task.
+    const lines = (rows as Array<{ id: string; status: string; process_after: string | null; recurrence: string | null; content: string | Uint8Array }>).map((r) => {
+      let prompt = '';
+      try {
+        const text = typeof r.content === 'string' ? r.content : new TextDecoder().decode(r.content);
+        const content = JSON.parse(text) as { prompt?: unknown };
+        prompt = (typeof content.prompt === 'string' ? content.prompt : '').slice(0, 80);
+      } catch {
+        prompt = '[corrupt content — see list_task_runs]';
+      }
       return `- ${r.id} [${r.status}] at=${r.process_after || 'now'} ${r.recurrence ? `recur=${r.recurrence} ` : ''}→ ${prompt}`;
     });
 

--- a/src/modules/scheduling/db.ts
+++ b/src/modules/scheduling/db.ts
@@ -60,6 +60,21 @@ export interface TaskUpdate {
   processAfter?: string;
 }
 
+// Defensive: a row's `content` column has TEXT affinity, but SQLite uses
+// manifest typing (per-row), and historical bugs (or a foreign writer) can
+// leave a row stored as BLOB. better-sqlite3 surfaces that as Buffer; bun:sqlite
+// in the container surfaces it as Uint8Array and JSON.parse() throws. If we
+// re-bind such a value untouched (insertRecurrence copies it forward on every
+// cron firing, updateTask rewrites the same row), the taint becomes hereditary
+// — every recurring fire produces another BLOB row and the container's
+// list_tasks breaks for the whole series. Coerce on the way back into the DB.
+function asText(c: unknown): string {
+  if (typeof c === 'string') return c;
+  if (Buffer.isBuffer(c)) return c.toString('utf8');
+  if (c instanceof Uint8Array) return Buffer.from(c).toString('utf8');
+  return String(c);
+}
+
 // Merges content JSON in-place so callers can update prompt/script without
 // clobbering other fields. Matches by id OR series_id so the live next
 // occurrence of a recurring task is updated, not just the completed row the
@@ -79,9 +94,10 @@ export function updateTask(db: Database.Database, taskId: string, update: TaskUp
 
   const tx = db.transaction(() => {
     for (const row of rows) {
-      let content = row.content;
+      const rowText = asText(row.content);
+      let content: string = rowText;
       if (mergeContent) {
-        const parsed = JSON.parse(row.content) as Record<string, unknown>;
+        const parsed = JSON.parse(rowText) as Record<string, unknown>;
         if (update.prompt !== undefined) parsed.prompt = update.prompt;
         if (update.script !== undefined) parsed.script = update.script;
         content = JSON.stringify(parsed);
@@ -143,7 +159,7 @@ export function insertRecurrence(
     msg.platform_id,
     msg.channel_type,
     msg.thread_id,
-    msg.content,
+    asText(msg.content),
     msg.series_id,
   );
 }


### PR DESCRIPTION
## Summary

`list_tasks` (the MCP tool the bot uses to find a `series_id` so it can `pause_task` / `cancel_task`) was throwing `JSON Parse error: Unable to parse JSON string` and burning every call once a single row in any task series got stored as SQLite BLOB instead of TEXT. With `list_tasks` blocked, the bot couldn't pause its own runaway recurring crons (the cluster-tour backlog-sweep was firing hourly with no way to stop it short of killing the host).

This fixes both the immediate symptom (one bad row sinking the whole listing) and the propagation paths that quietly tainted new rows on every cron firing.

## Root cause

- `messages_in.content` has TEXT affinity but SQLite uses **manifest typing** — the type is per-row. A row written as BLOB stays BLOB. (Original taint source: not in this repo's writers; suspected adapter or migration. Once one BLOB row exists, our recurrence loop keeps rewriting it forward.)
- Inside the container, `bun:sqlite` returns BLOB-typed columns as `Uint8Array`. `JSON.parse(Uint8Array)` throws in Bun (JSC error message format), and the previous `list_tasks` code had no guard.
- On the host, two writers were copying the bad value forward untouched:
  - `updateTask` rebound `row.content` (a `Buffer` from better-sqlite3 when the source row was BLOB) into the `UPDATE`, so the row stayed BLOB.
  - `insertRecurrence` re-inserted `msg.content` from `getCompletedRecurring` on every cron firing, so each occurrence created a fresh BLOB row.

## Fix

- **`container/agent-runner/src/mcp-tools/scheduling.ts`** — `list_tasks` now coerces `Uint8Array → string` via `TextDecoder` before `JSON.parse`, and wraps the parse in `try/catch`. A bad row renders as ``[corrupt content — see list_task_runs]`` instead of failing the whole listing. The agent keeps the ability to `pause_task` / `cancel_task` even when one occurrence is corrupt.
- **`src/modules/scheduling/db.ts`** — added an `asText(c)` helper (handles `string | Buffer | Uint8Array | other`) and use it in:
  - `updateTask` — coerce `row.content` to string before re-binding.
  - `insertRecurrence` — coerce `msg.content` to string before insert.

So even on a session DB that's already tainted, every UPDATE / recurrence INSERT going forward writes TEXT.

## Manual cleanup post-deploy (one-off)

The patch prevents *new* BLOB rows but doesn't heal existing ones. On each session DB carrying a tainted recurring series, run inside the container (or against the inbound.db on the host):

```sql
UPDATE messages_in SET content = CAST(content AS TEXT)
 WHERE typeof(content) = 'blob' AND kind = 'task';
```

This unblocks `list_tasks` on the live cluster-tour series (`task-1777553739158-*`) without waiting for natural attrition.

## Test plan

- [x] `pnpm run build` — host TS clean
- [x] `pnpm exec tsc -p container/agent-runner/tsconfig.json --noEmit` — container TS clean
- [x] `cd container/agent-runner && bun test` — 69/69 pass
- [x] `npx vitest run` — same 6 Windows-only EPERM flakes as baseline (`D:\tmp\nanoclaw-scheduling-db-test` lock contention from better-sqlite3, pre-existing); other 271+ tests unaffected
- [ ] Smoke: after merge + restart, call `list_tasks` from the bot — should return all live series without throwing, with the one tainted occurrence rendering as `[corrupt content — …]`. Apply the SQL cleanup to clear the placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)