### PR TITLE
fix(delivery): swallow transient SQLITE_READONLY on hot-journal recovery

### DIFF
--- a/PATCHES.md
+++ b/PATCHES.md
@@ -138,6 +138,14 @@ If none works, document the patch here with justification.
 - **Exit condition:** Upstream either accepts a PR adding the same test-singleton fast-path, or refactors `initTestSessionDb()` to write the in-memory DB to a real temp file path that `openInboundDb()` can open.
 - **Lines:** ~12 (guard + helper + 4 call-site renames).
 
+### 15. Swallow transient `SQLITE_READONLY` in delivery poll on hot-journal recovery
+
+- **File:** `src/db/session-db.ts` (new `isTransientSqliteReadonlyError` helper) + `src/delivery.ts` (wrap `getDueOutboundMessages` in `drainSession`)
+- **Summary:** When the host's 1s active delivery poll opens `outbound.db` read-only and `prepare(SELECT ... FROM messages_out)` runs while the container is mid-commit, `better-sqlite3` throws `SqliteError: attempt to write a readonly database`. The container uses `journal_mode=DELETE` (load-bearing for VirtioFS cross-mount visibility) so a `*-journal` file is the normal during-commit state — but readonly opens cannot recover the hot journal. Catch this specific transient case (code starts with `SQLITE_READONLY` or message matches `/readonly database/i`) and skip the tick; the next poll (~1s) sees a clean DB.
+- **Why:** Observed ~67 occurrences in 24h of `Active delivery poll error` log spam on myia-ai-01 (1s poll × ~5 transient hits/hour). Each error logs a full stack to `nanoclaw.err.log` despite being a benign race that resolves on the next tick. Without the swallow, the bug appears as constant noise that masks real delivery failures and clouds the on-call signal-to-noise.
+- **Exit condition:** Upstream applies this fix or the agent-runner switches to a journal mode (e.g. WAL with explicit checkpoint) that doesn't leave hot journals readable cross-mount. Filing upstream is straightforward — the helper is portable and the fix is purely defensive.
+- **Lines:** ~25 (helper + call-site wrap + 5 unit tests).
+
 ### 13. Filesystem-safe per-agent message id separator (`messageIdForAgent`)
 
 - **File:** `src/router.ts` (function `messageIdForAgent` at end of file)

--- a/src/db/session-db.test.ts
+++ b/src/db/session-db.test.ts
@@ -10,7 +10,11 @@ import fs from 'fs';
 import path from 'path';
 import { describe, it, expect, afterEach } from 'vitest';
 
-import { expireAncientScheduledMessages, migrateMessagesInTable } from './session-db.js';
+import {
+  expireAncientScheduledMessages,
+  isTransientSqliteReadonlyError,
+  migrateMessagesInTable,
+} from './session-db.js';
 
 const TEST_DIR = '/tmp/nanoclaw-session-db-test';
 const DB_PATH = path.join(TEST_DIR, 'inbound.db');
@@ -168,5 +172,51 @@ describe('expireAncientScheduledMessages', () => {
     const second = expireAncientScheduledMessages(db, cutoff);
     expect(second).toEqual([]);
     db.close();
+  });
+});
+
+describe('isTransientSqliteReadonlyError', () => {
+  it('detects SqliteError code starting with SQLITE_READONLY', () => {
+    const err = Object.assign(new Error('attempt to write a readonly database'), {
+      code: 'SQLITE_READONLY',
+    });
+    expect(isTransientSqliteReadonlyError(err)).toBe(true);
+  });
+
+  it('detects SQLITE_READONLY_RECOVERY (hot-journal recovery on RO open)', () => {
+    const err = Object.assign(new Error('attempt to write a readonly database'), {
+      code: 'SQLITE_READONLY_RECOVERY',
+    });
+    expect(isTransientSqliteReadonlyError(err)).toBe(true);
+  });
+
+  it('falls back to message regex when no code is set', () => {
+    const err = new Error('attempt to write a readonly database');
+    expect(isTransientSqliteReadonlyError(err)).toBe(true);
+  });
+
+  it('reproduces the error path in better-sqlite3 against a RO connection', () => {
+    if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+    fs.mkdirSync(TEST_DIR, { recursive: true });
+    const dbPath = path.join(TEST_DIR, 'ro-write.db');
+    new Database(dbPath).close();
+
+    const ro = new Database(dbPath, { readonly: true });
+    let caught: unknown;
+    try {
+      ro.prepare('CREATE TABLE x (v INTEGER)').run();
+    } catch (err) {
+      caught = err;
+    }
+    ro.close();
+    expect(caught).toBeDefined();
+    expect(isTransientSqliteReadonlyError(caught)).toBe(true);
+  });
+
+  it('rejects unrelated errors', () => {
+    expect(isTransientSqliteReadonlyError(new Error('disk full'))).toBe(false);
+    expect(isTransientSqliteReadonlyError(null)).toBe(false);
+    expect(isTransientSqliteReadonlyError(undefined)).toBe(false);
+    expect(isTransientSqliteReadonlyError('readonly database')).toBe(false);
   });
 });

--- a/src/db/session-db.ts
+++ b/src/db/session-db.ts
@@ -32,6 +32,27 @@ export function openOutboundDb(dbPath: string): Database.Database {
   return db;
 }
 
+/**
+ * [PATCH-myia] Transient read race against a writer that uses DELETE journal.
+ *
+ * outbound.db is owned by the container and runs `journal_mode=DELETE` (load-
+ * bearing for cross-mount visibility on VirtioFS). When the container is mid-
+ * commit, a `*-journal` file exists; SQLite then needs write access to recover
+ * the journal before serving any read. Our host-side opens are READ-ONLY, so
+ * `prepare()` throws `SqliteError: attempt to write a readonly database`.
+ *
+ * The condition is transient — the next 1s delivery tick (or 60s sweep tick)
+ * sees a clean DB. Callers should treat it as "skip this tick".
+ */
+export function isTransientSqliteReadonlyError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false;
+  const code = (err as { code?: unknown }).code;
+  if (typeof code === 'string' && code.startsWith('SQLITE_READONLY')) return true;
+  const message = (err as { message?: unknown }).message;
+  if (typeof message === 'string' && /readonly database/i.test(message)) return true;
+  return false;
+}
+
 /** Open the outbound DB for a session with write access. Only safe to call when no container is running. */
 export function openOutboundDbRw(dbPath: string): Database.Database {
   const db = new Database(dbPath);

--- a/src/delivery.ts
+++ b/src/delivery.ts
@@ -16,6 +16,7 @@ import { getMessagingGroupByPlatform } from './db/messaging-groups.js';
 import {
   getDueOutboundMessages,
   getDeliveredIds,
+  isTransientSqliteReadonlyError,
   markDelivered,
   markDeliveryFailed,
   migrateDeliveredTable,
@@ -175,8 +176,17 @@ async function drainSession(session: Session): Promise<void> {
   }
 
   try {
-    // Read all due messages from outbound.db (read-only)
-    const allDue = getDueOutboundMessages(outDb);
+    // Read all due messages from outbound.db (read-only).
+    // [PATCH-myia] If the container is mid-commit, the DELETE-journal write
+    // path leaves a `-journal` file that SQLite can't recover from a readonly
+    // open. Skip the tick — the next active poll (~1s) sees a clean DB.
+    let allDue: ReturnType<typeof getDueOutboundMessages>;
+    try {
+      allDue = getDueOutboundMessages(outDb);
+    } catch (err) {
+      if (isTransientSqliteReadonlyError(err)) return;
+      throw err;
+    }
     if (allDue.length === 0) return;
 
     // Filter out already-delivered messages using inbound.db's delivered table


### PR DESCRIPTION
## Summary

- Active delivery poll (1s) opens `outbound.db` read-only, but the container is the sole writer with `journal_mode=DELETE`. When the host's `prepare(SELECT ... FROM messages_out)` runs while a `*-journal` file exists (container mid-commit), SQLite needs write access to recover the hot journal — the readonly open can't, so it throws `SqliteError: attempt to write a readonly database`.
- The error is transient: the next 1s tick sees a clean DB.
- Detect this specific case (`code` starts with `SQLITE_READONLY` or `message` matches `/readonly database/i`) and skip the tick instead of bubbling up to `pollActive`'s catch — that catch logged a full stack to `nanoclaw.err.log` despite the issue being benign.
- Observed ~67 occurrences in 24h on myia-ai-01: pure noise that masked real delivery failures.

## What changed

- `src/db/session-db.ts` — new `isTransientSqliteReadonlyError(err)` helper.
- `src/delivery.ts` — wrap `getDueOutboundMessages(outDb)` in `drainSession`, swallow the transient error.
- `src/db/session-db.test.ts` — 5 unit tests including a real reproduction that opens an RO connection and tries to `prepare('CREATE TABLE …')`.
- `PATCHES.md` — adds entry #15 with exit condition.

## Why an overlay (not just a local fix)

The fix touches upstream files (`src/db/session-db.ts` + `src/delivery.ts`). Without an overlay entry it would create silent drift on the next sync. Filing upstream is plausible — the helper is portable and the fix is purely defensive.

## Test plan

- [x] `pnpm run build` — clean
- [x] `npx vitest run src/db/session-db.test.ts` — 9/9 pass (4 existing + 5 new)
- [x] `npx vitest run src/delivery.test.ts src/host-sweep.test.ts` — 19/19 pass
- [x] `npx vitest run` — 289/299 pass (10 fails are pre-existing Windows-only EPERM in `src/modules/scheduling/db.test.ts`, documented baseline)
- [x] Service restarted on myia-ai-01 at 23:48:44 — no new `Active delivery poll error` in `nanoclaw.err.log` since (file last writes contain only pre-fix entries up to 23:22:00).

🤖 Generated with [Claude Code](https://claude.com/claude-code)