### PR TITLE
fix(agent-runner): strip leaked MCP tool-call XML envelopes from output

### DIFF
--- a/PATCHES.md
+++ b/PATCHES.md
@@ -146,6 +146,14 @@ If none works, document the patch here with justification.
 - **Exit condition:** Upstream changes `messageIdForAgent` to use a filesystem-safe separator (e.g. `_`) or sanitizes the id before it reaches the inbox path.
 - **Lines:** ~10 (1 expression change + 8 lines of explanatory comment).
 
+### 16. Strip leaked MCP tool-call XML envelopes from agent output
+
+- **File:** `container/agent-runner/src/formatter.ts` (new helper `stripLeakedMcpToolcalls`) + `container/agent-runner/src/poll-loop.ts` (call site in `dispatchResultText`).
+- **Summary:** After `stripInternalTags`, run `stripLeakedMcpToolcalls` on the assistant text. Drops any `<mcp__server__tool …>…</mcp__server__tool>` paired blocks (back-reference matched) and `<mcp__server__tool … />` self-closing blocks; logs `WARNING: stripped N leaked MCP toolcall block(s)` so the incident is visible in container logs.
+- **Why:** z.ai's Anthropic-pretend endpoint occasionally emits the model's tool-call XML envelope as plain text instead of executing it. Without stripping, the dispatcher's single-destination fallback posts the raw `<mcp__nanoclaw__send_message>…</…>` (or `<mcp__nanoclaw__add_reaction />`) as a chat message — the user sees garbage, and worse: an intended private DM is exposed in the public group because the fallback ignores the `to=` parameter inside the leaked XML and always replies to the channel of origin. Recovery is unsafe (parameter conventions differ across MCPs and across model leak variants), so just drop the leak and rely on the next user message to retry.
+- **Exit condition:** Upstream applies the same defensive strip OR z.ai fixes the SDK envelope leak OR we switch the agent provider for this group off z.ai.
+- **Lines:** ~35 (helper) + ~10 (call site + WARNING log).
+
 ---
 
 ## Deferred / not yet applied

--- a/container/agent-runner/src/formatter.test.ts
+++ b/container/agent-runner/src/formatter.test.ts
@@ -13,7 +13,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 
 import { initTestSessionDb, closeSessionDb, getInboundDb } from './db/connection.js';
 import { getPendingMessages } from './db/messages-in.js';
-import { formatMessages, stripInternalTags } from './formatter.js';
+import { formatMessages, stripInternalTags, stripLeakedMcpToolcalls } from './formatter.js';
 import { TIMEZONE } from './timezone.js';
 
 beforeEach(() => {
@@ -163,5 +163,73 @@ describe('stripInternalTags', () => {
     expect(stripInternalTags('<internal>thinking</internal>The answer is 42')).toBe(
       'The answer is 42',
     );
+  });
+});
+
+describe('stripLeakedMcpToolcalls', () => {
+  it('strips a paired send_message envelope (multi-line)', () => {
+    const input = `Here is my answer.
+<mcp__nanoclaw__send_message>
+<parameter name="to">emerjesse</parameter>
+<parameter name="text">private note</parameter>
+</mcp__nanoclaw__send_message>
+Done.`;
+    const { cleaned, leakCount } = stripLeakedMcpToolcalls(input);
+    expect(leakCount).toBe(1);
+    expect(cleaned).not.toContain('<mcp__');
+    expect(cleaned).toContain('Here is my answer.');
+    expect(cleaned).toContain('Done.');
+  });
+
+  it('strips a self-closing add_reaction envelope', () => {
+    const input =
+      'Pre. <mcp__nanoclaw__add_reaction emoji="eyes" messageId="1398" /> Post.';
+    const { cleaned, leakCount } = stripLeakedMcpToolcalls(input);
+    expect(leakCount).toBe(1);
+    expect(cleaned).toBe('Pre.  Post.'.trim());
+  });
+
+  it('strips a paired add_reaction with empty body and attributes on opening tag', () => {
+    const input =
+      '<mcp__nanoclaw__add_reaction emoji="eyes" messageId="1398"></mcp__nanoclaw__add_reaction>';
+    const { cleaned, leakCount } = stripLeakedMcpToolcalls(input);
+    expect(leakCount).toBe(1);
+    expect(cleaned).toBe('');
+  });
+
+  it('strips multiple leaked blocks and counts them', () => {
+    const input = `<mcp__a__b>x</mcp__a__b> middle <mcp__c__d arg="1" />`;
+    const { cleaned, leakCount } = stripLeakedMcpToolcalls(input);
+    expect(leakCount).toBe(2);
+    expect(cleaned).toBe('middle');
+  });
+
+  it('does not strip ordinary <message to="..."> blocks', () => {
+    const input = '<message to="emerjesse">hi</message>';
+    const { cleaned, leakCount } = stripLeakedMcpToolcalls(input);
+    expect(leakCount).toBe(0);
+    expect(cleaned).toBe(input);
+  });
+
+  it('does not strip non-mcp HTML-like tags', () => {
+    const input = '<b>bold</b> <i>italic</i>';
+    const { cleaned, leakCount } = stripLeakedMcpToolcalls(input);
+    expect(leakCount).toBe(0);
+    expect(cleaned).toBe(input);
+  });
+
+  it('returns empty + leakCount when input is only leaked XML', () => {
+    const input = `<mcp__nanoclaw__send_message><parameter name="to">x</parameter></mcp__nanoclaw__send_message>`;
+    const { cleaned, leakCount } = stripLeakedMcpToolcalls(input);
+    expect(leakCount).toBe(1);
+    expect(cleaned).toBe('');
+  });
+
+  it('does not match mismatched server/tool tag pairs (back-reference enforced)', () => {
+    // Open vs close differ → not a real paired block; left intact.
+    const input = '<mcp__a__b>x</mcp__c__d>';
+    const { cleaned, leakCount } = stripLeakedMcpToolcalls(input);
+    expect(leakCount).toBe(0);
+    expect(cleaned).toBe(input);
   });
 });

--- a/container/agent-runner/src/formatter.ts
+++ b/container/agent-runner/src/formatter.ts
@@ -278,3 +278,38 @@ function escapeXml(str: string): string {
 export function stripInternalTags(text: string): string {
   return text.replace(/<internal>[\s\S]*?<\/internal>/g, '').trim();
 }
+
+/**
+ * Strip leaked MCP tool-call XML from agent output.
+ *
+ * On z.ai's Anthropic-pretend endpoint, the model sometimes emits its
+ * tool-call XML envelope as plain text instead of executing it. Examples:
+ *   <mcp__nanoclaw__send_message>
+ *     <parameter name="to">emerjesse</parameter>
+ *     <parameter name="text">…</parameter>
+ *   </mcp__nanoclaw__send_message>
+ *   <mcp__nanoclaw__add_reaction emoji="eyes" messageId="1398"></mcp__nanoclaw__add_reaction>
+ *   <mcp__server__tool arg="x" />
+ *
+ * Without stripping, the dispatcher's single-destination fallback posts
+ * the raw XML as a chat message — the user sees garbage, and the
+ * agent's intended action (e.g. private DM) is exposed publicly.
+ *
+ * Recovery is unsafe (multiple format variants, parameter conventions
+ * differ across MCPs); just drop the leak and log a warning so the
+ * incident is visible.
+ */
+export function stripLeakedMcpToolcalls(text: string): { cleaned: string; leakCount: number } {
+  let leakCount = 0;
+  // Paired block (back-reference enforces matching open/close tag).
+  let cleaned = text.replace(/<(mcp__\w+__\w+)\b[^>]*>[\s\S]*?<\/\1>/g, () => {
+    leakCount++;
+    return '';
+  });
+  // Self-closing block.
+  cleaned = cleaned.replace(/<mcp__\w+__\w+\b[^>]*\/\s*>/g, () => {
+    leakCount++;
+    return '';
+  });
+  return { cleaned: cleaned.trim(), leakCount };
+}

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -8,7 +8,16 @@ import {
   migrateLegacyContinuation,
   setContinuation,
 } from './db/session-state.js';
-import { formatMessages, extractRouting, categorizeMessage, isClearCommand, isRunnerCommand, stripInternalTags, type RoutingContext } from './formatter.js';
+import {
+  formatMessages,
+  extractRouting,
+  categorizeMessage,
+  isClearCommand,
+  isRunnerCommand,
+  stripInternalTags,
+  stripLeakedMcpToolcalls,
+  type RoutingContext,
+} from './formatter.js';
 import { formatFailures, probeMcpRemoteCached, type RequiredRemote } from './mcp-health.js';
 import type { AgentProvider, AgentQuery, ProviderEvent } from './providers/types.js';
 
@@ -569,7 +578,14 @@ function dispatchResultText(text: string, routing: RoutingContext): void {
     scratchpadParts.push(text.slice(lastIndex));
   }
 
-  const scratchpad = stripInternalTags(scratchpadParts.join(''));
+  const internalStripped = stripInternalTags(scratchpadParts.join(''));
+  // Defensive: z.ai SDK occasionally leaks `<mcp__server__tool>...</...>`
+  // tool-call envelopes as plain text. Without this strip, the fallback
+  // below posts the raw XML to the user-facing channel.
+  const { cleaned: scratchpad, leakCount } = stripLeakedMcpToolcalls(internalStripped);
+  if (leakCount > 0) {
+    log(`WARNING: stripped ${leakCount} leaked MCP toolcall block(s) from agent output (z.ai SDK known issue)`);
+  }
 
   // Single-destination shortcut: the agent wrote plain text — send to
   // the session's originating channel (from session_routing) if available,


### PR DESCRIPTION
## Summary

z.ai's Anthropic-pretend SDK occasionally emits the model's tool-call XML envelope as plain text instead of executing it. Without stripping, the dispatcher's single-destination fallback posts the raw `<mcp__nanoclaw__send_message>...</...>` block to the user-facing channel — the user sees garbage and any intended private DM is exposed publicly.

## Root cause

When the SDK's tool-router fails to recognize the leaked `<mcp__server__tool>` envelope, the agent's textual reply still contains it. `dispatchResultText` then enters the single-destination fallback (no `<message to="…">` blocks found), which uses the **inbound channel** as the destination — completely ignoring any `to=` parameter inside the leaked XML. Result: an intended private DM ends up in the public group.

## Fix

- New helper `stripLeakedMcpToolcalls(text)` in `container/agent-runner/src/formatter.ts`
  - Drops `<mcp__\w+__\w+ ...>...</same-tag>` paired blocks (back-reference enforces matching open/close)
  - Drops self-closing `<mcp__\w+__\w+ ... />` blocks
  - Returns `{ cleaned, leakCount }` so the call site can log the leak
- Wired into `dispatchResultText` after `stripInternalTags`; emits `WARNING: stripped N leaked MCP toolcall block(s)` to container logs when it fires
- 8 unit tests covering paired + self-closing variants, mismatched server/tool tags (rejected by back-reference), non-mcp tags preserved
- Documented in `PATCHES.md` #16 with exit condition

Recovery (parsing the leaked XML and dispatching it as a real tool-call) is unsafe because parameter conventions differ across MCPs and across model leak variants — the safer choice is to drop the leak; the user retries on the next message.

## Test plan

- [x] `bun test` in `container/agent-runner/` — 85/85 pass
- [x] `bun run typecheck` — clean
- [x] `pnpm run build` (host) — clean
- [x] Container image rebuilt: `nanoclaw-agent-v2-9a858fd9:latest`
- [ ] Service restart + observe production logs for `WARNING: stripped N leaked MCP toolcall block(s)` events

## Context

This is the second half of a two-part fix. The first half (PR #35, `fix/delivery-readonly-transient`) addressed the read-only DB error spam. This PR addresses the user-visible symptom that originally prompted the investigation: **the agent replies in DM instead of group chat** — root-caused to leaked tool-call XML routing through the fallback dispatcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)