### PR TITLE
fix(poll-loop): recover lost messages on push-mode SDK stall (PATCH #18)

### DIFF
--- a/PATCHES.md
+++ b/PATCHES.md
@@ -170,6 +170,14 @@ If none works, document the patch here with justification.
 - **Exit condition:** Upstream `src/cli/socket-server.ts` adds platform detection or a config hook for the listen path, OR we deprecate the host-side socket server in favor of the container's DB transport for shell invocations too.
 - **Lines:** ~14 (new helper + 3 call-site swaps + win32 guard on cleanup/chmod).
 
+### 18. Push-mode stall recovery in container poll-loop
+
+- **File:** `container/agent-runner/src/poll-loop.ts` (defer `markCompleted` for follow-ups + 90s stall watchdog), `container/agent-runner/src/db/messages-in.ts` (new `resetProcessingAcks()` helper).
+- **Summary:** When a follow-up batch is pushed into an active SDK query, no longer mark those messages `completed` immediately after `query.push()`. Instead, queue their IDs in `pendingFollowUpAcks[]` and only commit the `markCompleted` when the SDK emits a corresponding `result` event (or, if the stream ends without one, reset their `processing_ack` rows for retry). A separate watchdog interval checks every 5s whether `lastPushAt` is older than `STALL_TIMEOUT_MS=90s` — if so, reset the pushed messages back to pending and `query.abort()` the stalled SDK query so the outer poll loop respawns with a fresh stream.
+- **Why:** Push-mode stalls (upstream qwibitai/nanoclaw#2177, recurring in long-lived sessions especially under z.ai's Anthropic-pretend endpoint) silently swallow user messages. Pre-fix flow: `query.push(prompt)` → `markCompleted(keptIds)` immediately → SDK never emits a matching `result` event → messages are gone from the queue and never re-tried. Observed 2026-05-09 evening: a 12-hour-old container produced one final result at 22:00:35 (in reply to a CRON task), but two earlier user messages routed at 21:53:35 and 21:57:56 were marked `completed` in `processing_ack` and have NO corresponding row in `messages_out`. User-visible symptom: "the bot ignored my last 2 messages, then answered something unrelated." The host-sweep watchdog (`ABSOLUTE_CEILING_MS=30min` heartbeat-based, `CLAIM_STUCK_MS=60s` claim-based) cannot catch this because heartbeat stays fresh and claims never lingered (they were marked completed pre-result).
+- **Exit condition:** Upstream adopts deferred-ack-on-result semantics (PR target), OR the underlying SDK exposes a per-push acknowledgment hook so the poll-loop can do strict 1-to-1 mapping, OR push-mode is replaced with end+restart-per-batch.
+- **Lines:** ~50 (deferred-ack tracking + watchdog interval + `resetProcessingAcks` helper + finally-block reset for clean abort paths).
+
 ---
 
 ## Deferred / not yet applied

--- a/container/agent-runner/src/db/messages-in.test.ts
+++ b/container/agent-runner/src/db/messages-in.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+
+import { getInboundDb, getOutboundDb, initTestSessionDb } from './connection.js';
+import {
+  getPendingMessages,
+  markCompleted,
+  markProcessing,
+  resetProcessingAcks,
+} from './messages-in.js';
+
+beforeEach(() => {
+  initTestSessionDb();
+});
+
+function seedMessage(id: string): void {
+  getInboundDb()
+    .prepare(
+      `INSERT INTO messages_in (id, kind, timestamp, status, trigger, content)
+       VALUES (?, 'chat', datetime('now'), 'pending', 1, '{"text":"hi"}')`,
+    )
+    .run(id);
+}
+
+describe('resetProcessingAcks (PATCH-myia #18)', () => {
+  test('removes processing claim — message becomes pending again', () => {
+    seedMessage('m1');
+    markProcessing(['m1']);
+    expect(getPendingMessages().map((m) => m.id)).toEqual([]);
+
+    resetProcessingAcks(['m1']);
+    expect(getPendingMessages().map((m) => m.id)).toEqual(['m1']);
+  });
+
+  test('removes completed claim — message becomes re-processable', () => {
+    // Push-mode stall scenario: a follow-up was marked completed (pre-fix
+    // behavior) but the SDK never produced a result. Reset clears the row
+    // so the message can be retried.
+    seedMessage('m1');
+    markProcessing(['m1']);
+    markCompleted(['m1']);
+    expect(getPendingMessages().map((m) => m.id)).toEqual([]);
+
+    resetProcessingAcks(['m1']);
+    expect(getPendingMessages().map((m) => m.id)).toEqual(['m1']);
+  });
+
+  test('no-op on empty list', () => {
+    seedMessage('m1');
+    markProcessing(['m1']);
+    resetProcessingAcks([]);
+    // Original claim still in place.
+    expect(getPendingMessages().map((m) => m.id)).toEqual([]);
+  });
+
+  test('only resets the specified ids', () => {
+    seedMessage('m1');
+    seedMessage('m2');
+    markProcessing(['m1', 'm2']);
+    resetProcessingAcks(['m1']);
+
+    const rows = getOutboundDb()
+      .prepare('SELECT message_id, status FROM processing_ack ORDER BY message_id')
+      .all() as Array<{ message_id: string; status: string }>;
+    expect(rows).toEqual([{ message_id: 'm2', status: 'processing' }]);
+
+    expect(getPendingMessages().map((m) => m.id)).toEqual(['m1']);
+  });
+});

--- a/container/agent-runner/src/db/messages-in.ts
+++ b/container/agent-runner/src/db/messages-in.ts
@@ -116,6 +116,22 @@ export function markFailed(id: string): void {
     .run(id);
 }
 
+// [PATCH-myia #18] Push-mode stall recovery — see poll-loop.ts processQuery.
+// When a follow-up batch is pushed into an active SDK query but the SDK never
+// emits a corresponding `result` event (push-mode stall, observed in z.ai SDK
+// and recurring upstream issue #2177), the messages must NOT stay marked
+// `completed` (current behavior loses them silently). Instead the watchdog
+// resets their processing_ack rows and aborts the query, letting the outer
+// poll loop re-pick them with a fresh SDK query on the next iteration.
+export function resetProcessingAcks(ids: string[]): void {
+  if (ids.length === 0) return;
+  const db = getOutboundDb();
+  const stmt = db.prepare('DELETE FROM processing_ack WHERE message_id = ?');
+  db.transaction(() => {
+    for (const id of ids) stmt.run(id);
+  })();
+}
+
 /** Get a message by ID (read from inbound.db). */
 export function getMessageIn(id: string): MessageInRow | undefined {
   const inbound = openInboundDb();

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -1,5 +1,11 @@
 import { findByName, getAllDestinations, type DestinationEntry } from './destinations.js';
-import { getPendingMessages, markProcessing, markCompleted, type MessageInRow } from './db/messages-in.js';
+import {
+  getPendingMessages,
+  markProcessing,
+  markCompleted,
+  resetProcessingAcks, // [PATCH-myia #18]
+  type MessageInRow,
+} from './db/messages-in.js';
 import { writeMessageOut } from './db/messages-out.js';
 import { getInboundDb, touchHeartbeat, clearStaleProcessingAcks } from './db/connection.js';
 import { recordTaskRun } from './db/task-run-logs.js'; // [PATCH-myia #9]
@@ -21,6 +27,19 @@ import type { AgentProvider, AgentQuery, ProviderEvent } from './providers/types
 
 const POLL_INTERVAL_MS = 1000;
 const ACTIVE_POLL_INTERVAL_MS = 500;
+
+// [PATCH-myia #18] Push-mode stall watchdog. If we push a follow-up batch into
+// an active SDK query and don't see a `result` event within this window, we
+// treat the query as stalled, reset the pushed messages back to pending (so
+// the next poll iteration re-picks them) and abort the query. Without this,
+// pushes that the SDK silently fails to address are lost (the messages were
+// being marked `completed` immediately after `query.push()`).
+//
+// 90s chosen as: long enough to cover normal SDK turn latency including tool
+// calls (~10-30s typical, 60s for slow MCP), short enough to recover before
+// the user notices "the bot didn't reply".
+const STALL_TIMEOUT_MS = 90_000;
+const STALL_CHECK_INTERVAL_MS = 5_000;
 
 function log(msg: string): void {
   console.error(`[poll-loop] ${msg}`);
@@ -399,6 +418,16 @@ async function processQuery(
   // will kill the container and messages get reset to pending.
   let pollInFlight = false;
   let endedForCommand = false;
+
+  // [PATCH-myia #18] Push-mode stall recovery state.
+  // - pendingFollowUpAcks: follow-up message IDs whose markCompleted is deferred
+  //   until a `result` event arrives. Empty when the query is idle / fully drained.
+  // - lastPushAt: timestamp of the most recent query.push(); reset on each
+  //   `result` event. Used by the stall watchdog to decide when to give up.
+  // - stalledAborted: latched once the watchdog fired, prevents racy double-aborts.
+  const pendingFollowUpAcks: string[] = [];
+  let lastPushAt: number | null = null;
+  let stalledAborted = false;
   const pollHandle = setInterval(() => {
     if (done || pollInFlight || endedForCommand) return;
     pollInFlight = true;
@@ -461,7 +490,14 @@ async function processQuery(
         const prompt = formatMessages(keep);
         log(`Pushing ${keep.length} follow-up message(s) into active query`);
         query.push(prompt);
-        markCompleted(keptIds);
+        // [PATCH-myia #18] Defer markCompleted until a `result` event arrives.
+        // The previous behavior marked these completed immediately after push,
+        // which silently lost messages whenever the SDK failed to emit a
+        // matching result event (push-mode stall). Now they stay in
+        // `processing` state and are either drained on the next result event,
+        // or reset+retried by the stall watchdog below.
+        pendingFollowUpAcks.push(...keptIds);
+        lastPushAt = Date.now();
       } catch (err) {
         // Without this catch the rejection escapes the void IIFE and Node
         // terminates the container on unhandled-rejection. The initial-batch
@@ -474,6 +510,39 @@ async function processQuery(
       }
     })();
   }, ACTIVE_POLL_INTERVAL_MS);
+
+  // [PATCH-myia #18] Stall watchdog — every STALL_CHECK_INTERVAL_MS, check
+  // whether a pushed follow-up has been awaiting a result for longer than
+  // STALL_TIMEOUT_MS. If so, reset the pushed messages back to pending (clear
+  // their processing_ack rows) and abort the active SDK query. The outer
+  // poll loop will then re-pick those messages on its next iteration with a
+  // fresh query.
+  const stallHandle = setInterval(() => {
+    if (done || stalledAborted) return;
+    if (lastPushAt === null) return;
+    const elapsed = Date.now() - lastPushAt;
+    if (elapsed < STALL_TIMEOUT_MS) return;
+
+    log(
+      `STALL DETECTED: ${pendingFollowUpAcks.length} follow-up(s) awaiting result for ${Math.round(
+        elapsed / 1000,
+      )}s. Resetting acks and aborting query.`,
+    );
+    stalledAborted = true;
+    if (pendingFollowUpAcks.length > 0) {
+      try {
+        resetProcessingAcks(pendingFollowUpAcks);
+      } catch (err) {
+        log(`Failed to reset processing acks during stall: ${err instanceof Error ? err.message : String(err)}`);
+      }
+      pendingFollowUpAcks.length = 0;
+    }
+    try {
+      query.abort();
+    } catch (err) {
+      log(`Failed to abort stalled query: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }, STALL_CHECK_INTERVAL_MS);
 
   try {
     for await (const event of query.events) {
@@ -497,6 +566,16 @@ async function processQuery(
         // (send_message) mid-turn, or the message may not need a response
         // at all — either way the turn is finished.
         markCompleted(initialBatchIds);
+        // [PATCH-myia #18] Drain deferred follow-up acks. Any follow-up
+        // pushed since the last result is considered acknowledged by THIS
+        // result event (the SDK may merge multiple pushes into one result
+        // text — that's expected). Reset stall tracking for the next push
+        // cycle.
+        if (pendingFollowUpAcks.length > 0) {
+          markCompleted(pendingFollowUpAcks);
+          pendingFollowUpAcks.length = 0;
+        }
+        lastPushAt = null;
         if (event.text) {
           dispatchResultText(event.text, routing);
         }
@@ -532,6 +611,23 @@ async function processQuery(
   } finally {
     done = true;
     clearInterval(pollHandle);
+    clearInterval(stallHandle); // [PATCH-myia #18]
+    // [PATCH-myia #18] If the stream ended (cleanly or via abort) while we
+    // still had follow-up acks pending, the watchdog already reset them; but
+    // if the stream ended for some OTHER reason (e.g. SDK internal error,
+    // mcp_tool_missing path) we must reset them here too — otherwise those
+    // messages stay stuck in `processing` forever and never get re-picked.
+    if (pendingFollowUpAcks.length > 0 && !stalledAborted) {
+      log(
+        `Stream ended with ${pendingFollowUpAcks.length} follow-up(s) still pending — resetting acks for retry`,
+      );
+      try {
+        resetProcessingAcks(pendingFollowUpAcks);
+      } catch (err) {
+        log(`Failed to reset processing acks at stream end: ${err instanceof Error ? err.message : String(err)}`);
+      }
+      pendingFollowUpAcks.length = 0;
+    }
   }
 
   return { continuation: queryContinuation, mcpRegistryLost };


### PR DESCRIPTION
## Summary

Fixes a bug where the bot silently swallows user messages when the SDK query stalls during push-mode follow-ups. Observed 2026-05-09 evening on this install: a 12-hour-old container marked two user messages routed at 21:53:35 and 21:57:56 as \`completed\` in \`processing_ack\` but produced **no corresponding \`messages_out\` row**. User-visible symptom: \"the bot ignored my last 2 messages, then answered something unrelated.\"

## Root cause

[\`poll-loop.ts:464\`](container/agent-runner/src/poll-loop.ts) (pre-fix) called \`markCompleted(keptIds)\` **immediately after** \`query.push(prompt)\`, without waiting for the SDK to emit a corresponding \`result\` event. If the SDK silently failed to address that push (push-mode stall, recurring upstream issue qwibitai/nanoclaw#2177), the messages were marked completed and lost forever — \`getPendingMessages\` filters them out via \`processing_ack\` on the next iteration.

The host-side watchdog (\`ABSOLUTE_CEILING_MS=30min\` heartbeat-based, \`CLAIM_STUCK_MS=60s\` claim-based) cannot catch this case because:
- Heartbeat stays fresh (the container *is* alive — it's the SDK query that's stalled)
- Claims never linger in \`processing\` (they were marked completed pre-result)

## Fix

1. **Defer markCompleted for follow-ups until \`result\` event** — track pushed IDs in \`pendingFollowUpAcks[]\`, drain them in batch when a result fires (the SDK may merge multiple pushes into one result text — that's expected). Removes the silent-loss window.
2. **90s stall watchdog** — every 5s, if a follow-up has been awaiting a result for longer than \`STALL_TIMEOUT_MS=90s\`, \`resetProcessingAcks()\` the IDs (clears their \`processing_ack\` rows so \`getPendingMessages\` sees them again) and \`query.abort()\` the stalled SDK query. Outer poll loop re-picks them on next iteration with a fresh stream.
3. **finally-block reset** — if the stream ends for some other reason without a result (e.g. \`mcp_tool_missing\` path), reset any lingering follow-up acks for retry.

The host-sweep \`CLAIM_STUCK_MS=60s\` rule **also** now catches this case as a bonus safety net, since claims linger as \`processing\` instead of being pre-marked completed.

## Test plan

- [x] Unit tests for \`resetProcessingAcks\` (4 cases) — \`bun test src/db/messages-in.test.ts\` ✅ 4/4
- [x] Full container test suite — \`bun test\` ✅ 115/115
- [x] Container TypeScript typecheck — \`tsc -p container/agent-runner/tsconfig.json --noEmit\` ✅
- [x] Deployed: nanoclaw service restarted 2026-05-10 00:09 local; new container will load patched code on next message
- [ ] End-to-end: monitor next user-message round-trip + observe whether stall watchdog fires under load

## Documented in [PATCHES.md](PATCHES.md) as PATCH-myia #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)