### PR TITLE
fix(poll-loop): fallback dispatch when agent omits <message to=...> wrapping (PATCH #19)

### DIFF
--- a/PATCHES.md
+++ b/PATCHES.md
@@ -179,6 +179,14 @@ If none works, document the patch here with justification.
 - **Exit condition:** Upstream adopts deferred-ack-on-result semantics + periodic refresh (PR target), OR the underlying SDK exposes a per-push acknowledgment hook so the poll-loop can do strict 1-to-1 mapping, OR push-mode is replaced with end+restart-per-batch.
 - **Lines:** ~60 (deferred-ack tracking + watchdog interval + `resetProcessingAcks` helper + finally-block reset + periodic refresh check on `result` event).
 
+### 19. Routing-source fallback when agent omits `<message to="...">` wrapping
+
+- **File:** `container/agent-runner/src/poll-loop.ts` (`dispatchResultText` — added fallback branch before the silent-drop log path).
+- **Summary:** If the agent produces non-empty text but fails to wrap any of it in `<message to="...">` blocks, send the cleaned scratchpad to the source of the inbound that triggered the turn (`routing.platformId` + `routing.channelType` + `routing.threadId` + `routing.inReplyTo`). Pre-fix path: log `WARNING: agent output had no <message to="..."> blocks — nothing was sent` and return — i.e. silently drop the agent's reply.
+- **Why:** Observed 2026-05-10: container active 1h, MCP registry was lost mid-session and the SDK rebuilt a fresh query without the destination-wrapping discipline. User sent 4 inbound messages; only 2 outbound rows existed (one auto-error about MCP loss, one partial reply). Container log showed `Result: Mémoire mise à jour. J'attends ta réponse...` followed immediately by `[scratchpad] …` and `WARNING: agent output had no <message to="..."> blocks` — the agent DID generate a reply, but it was thrown away because the wrapping was missing. From the user's POV this looks identical to "the bot ignored me", which is the symptom that motivates this patch (user feedback: "nanoclaw est devenu quasiement inutile en conversation"). Better a reply that goes back to the source channel (the one place we know it's safe) than total silence. Triggered most often by MCP registry loss → continuation cleared → fresh SDK init that drops the wrapping convention.
+- **Exit condition:** Upstream adds the same source-channel fallback in `dispatchResultText` OR the agent provider stops dropping the `<message to="...">` discipline after MCP-init churn (e.g. system-prompt re-send on every fresh query, or stricter SDK guidance).
+- **Lines:** ~20 (one fallback branch in `dispatchResultText` + comment block + one-line docstring update on the surrounding function).
+
 ---
 
 ## Deferred / not yet applied

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -691,10 +691,13 @@ function handleEvent(event: ProviderEvent, _routing: RoutingContext): void {
 /**
  * Parse the agent's final text for <message to="name">...</message> blocks
  * and dispatch each one to its resolved destination. Text outside of blocks
- * (including <internal>...</internal>) is scratchpad — logged but not sent.
+ * is sent verbatim to the routing source as a fallback (PATCH-myia #19).
  *
- * The agent must always wrap output in <message to="name">...</message>
- * blocks, even with a single destination. Bare text is scratchpad only.
+ * The agent SHOULD wrap output in <message to="name">...</message> blocks
+ * to address specific destinations. When it forgets (often after MCP
+ * registry loss + continuation reset, or after auto-compaction), the
+ * fallback ensures the user still gets the reply on the channel they
+ * messaged from — better than silently dropping it into scratchpad.
  */
 function dispatchResultText(text: string, routing: RoutingContext): void {
   const MESSAGE_RE = /<message\s+to="([^"]+)"\s*>([\s\S]*?)<\/message>/g;
@@ -732,6 +735,39 @@ function dispatchResultText(text: string, routing: RoutingContext): void {
   const { cleaned: scratchpad, leakCount } = stripLeakedMcpToolcalls(internalStripped);
   if (leakCount > 0) {
     log(`WARNING: stripped ${leakCount} leaked MCP toolcall block(s) from agent output (z.ai SDK known issue)`);
+  }
+
+  // [PATCH-myia #19] Routing-source fallback. If the agent produced text but
+  // failed to wrap any of it in `<message to="...">` blocks, send the cleaned
+  // scratchpad to the source of the inbound that triggered this turn. The
+  // alternative (current upstream behavior) is to silently drop the reply,
+  // which from the user's POV looks identical to "the bot ignored me." This
+  // recurs especially after MCP registry loss → continuation cleared → fresh
+  // SDK init that sometimes drops the destination-wrapping discipline.
+  //
+  // We only fall back when:
+  //   - sent === 0 (no <message> blocks succeeded)
+  //   - scratchpad has substantive content (not just whitespace)
+  //   - routing has a usable channel (platformId + channelType)
+  if (
+    sent === 0 &&
+    scratchpad.trim().length > 0 &&
+    routing.platformId &&
+    routing.channelType
+  ) {
+    log(
+      `FALLBACK: agent output had no <message to="..."> blocks — sending ${scratchpad.length} chars to routing source (${routing.channelType}:${routing.platformId})`,
+    );
+    writeMessageOut({
+      id: generateId(),
+      in_reply_to: routing.inReplyTo,
+      kind: 'chat',
+      platform_id: routing.platformId,
+      channel_type: routing.channelType,
+      thread_id: routing.threadId ?? null,
+      content: JSON.stringify({ text: scratchpad.trim() }),
+    });
+    return;
   }
 
   if (scratchpad) {


### PR DESCRIPTION
## Summary

When the SDK produces non-empty text but the agent forgets to wrap any of it in `<message to="...">` blocks, the pre-fix dispatcher logged a `WARNING` and silently dropped the reply. From the user's POV this is identical to "the bot ignored me" — the visible symptom that motivated this patch.

## Fix

In `dispatchResultText` (poll-loop.ts:702), if `sent === 0` and the cleaned scratchpad has substantive content and `routing` has a usable channel, send the scratchpad to the source of the inbound that triggered this turn:

- `platform_id` ← `routing.platformId`
- `channel_type` ← `routing.channelType`
- `thread_id` ← `routing.threadId`
- `in_reply_to` ← `routing.inReplyTo`

## Trigger / repro

Observed 2026-05-10: container active 1h, MCP registry was lost mid-session and the SDK rebuilt a fresh query without the destination-wrapping discipline. User sent 4 inbound messages; only 2 outbound rows existed (one auto-error about MCP loss, one partial reply). Container log:

```
Result: Mémoire mise à jour. J'attends ta réponse...
[scratchpad] Mémoire mise à jour. J'attends ta réponse...
WARNING: agent output had no <message to="..."> blocks — nothing was sent
```

The agent DID generate a reply — it was thrown away because the wrapping was missing.

## Why fallback to the routing source

Better a reply that lands on the source channel (the only place we know is safe — it's the inbound's own channel) than total silence. We do NOT broadcast or guess destinations.

## Tests

- `bun test src/db/messages-in.test.ts` — 4/4 pass (PATCH #18 helpers still green)
- `pnpm exec tsc -p container/agent-runner/tsconfig.json --noEmit` — clean

## Test plan

- [ ] After deploy, watch `logs/nanoclaw.log` for `FALLBACK:` lines on user-replies that lack `<message to="...">` wrapping
- [ ] Verify a reply still reaches the user even when MCP registry is lost mid-turn
- [ ] Confirm normal `<message to="...">`-wrapped output still routes correctly (no regression)

PATCHES.md updated with PATCH #19 entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)