### PR TITLE
fix(transcription): retry transient ASR failures (PATCH #20)

### DIFF
--- a/PATCHES.md
+++ b/PATCHES.md
@@ -179,6 +179,17 @@ If none works, document the patch here with justification.
 - **Exit condition:** Upstream adopts deferred-ack-on-result semantics + periodic refresh (PR target), OR the underlying SDK exposes a per-push acknowledgment hook so the poll-loop can do strict 1-to-1 mapping, OR push-mode is replaced with end+restart-per-batch.
 - **Lines:** ~60 (deferred-ack tracking + watchdog interval + `resetProcessingAcks` helper + finally-block reset + periodic refresh check on `result` event).
 
+### 20. Retry transient ASR failures in `transcription.ts`
+
+- **File:** `src/transcription.ts` (`transcribeAudioBuffer` retry loop).
+- **Summary:** Wrap the ASR fetch + status-check in a 3-attempt loop with backoff `[200ms, 600ms]`. Retry on `TypeError: fetch failed` (network / SSL handshake / DNS) and on HTTP `5xx`. Do NOT retry on 4xx (auth, malformed). Log warnings on each retry, error only when all attempts are exhausted. The `FormData` is rebuilt on each attempt because `Blob` streams are single-use.
+- **Why:** Observed 2026-05-10 in `nanoclaw.err.log`: 5× `Transcription error TypeError fetch failed` + 2× `Transcription request failed status=500` spread across the day, while the same endpoint produced 142 successful transcriptions. Drops are silent from the user's POV — no `🎤` echo, agent never sees `[Voice: ...]` inline → bot looks like it ignored the voice. Two distinct intermittent modes:
+  - SSL chain instability on `whisper-api.myia.io` (cert chain incomplete from ARR po-2023; Node fetch fails sporadically depending on which CA chain it tries to verify against).
+  - Whisper backend on po-2023 returning sporadic 500 (server-side hiccup, recovers on next call).
+  Both are recoverable with a quick retry. Persistent outages still surface as `Transcription error attempt=3` after exhausting attempts.
+- **Exit condition:** ARR `whisper-api.myia.io` serves the full intermediate cert chain (PowerShell strict accepts it without `-SkipCertificateCheck`), AND po-2023 Whisper stops emitting transient 500s, OR upstream NanoClaw adds native retry/backoff to its ASR path.
+- **Lines:** ~50 (3-attempt loop with attempt-aware logging + helper to rebuild FormData per attempt).
+
 ### 19. Routing-source fallback when agent omits `<message to="...">` wrapping
 
 - **File:** `container/agent-runner/src/poll-loop.ts` (`dispatchResultText` — added fallback branch before the silent-drop log path).

--- a/src/transcription.ts
+++ b/src/transcription.ts
@@ -37,6 +37,25 @@ export function isTranscriptionEnabled(): boolean {
   return loadConfig() !== null;
 }
 
+// [PATCH-myia #20] Retry on transient ASR failures.
+// Observed 2026-05-10: 5× fetch failed (SSL/network) + 2× 500 Internal Server
+// Error spread across the day, while the same endpoint also produced 142
+// successful transcriptions. The drops are silent from the user's POV (no
+// 🎤 echo, agent never sees the [Voice: ...] inline) → the bot looks like
+// it ignored the voice message. Retrying transient failures fixes the
+// user-visible symptom without masking persistent outages.
+const TRANSCRIBE_MAX_ATTEMPTS = 3;
+const TRANSCRIBE_RETRY_BACKOFF_MS = [200, 600];
+
+function buildTranscribeForm(buffer: Buffer, filename: string, mimeType: string, config: AsrConfig): FormData {
+  const form = new FormData();
+  form.append('file', new Blob([buffer], { type: mimeType }), filename);
+  form.append('model', config.model);
+  if (config.language) form.append('language', config.language);
+  if (config.prompt) form.append('prompt', config.prompt);
+  return form;
+}
+
 /**
  * Transcribe an in-memory audio buffer via an OpenAI-compatible
  * /audio/transcriptions endpoint. Returns transcript text, or null if
@@ -46,6 +65,9 @@ export function isTranscriptionEnabled(): boolean {
  * no disk round-trip needed. Bearer auth via ASR_API_KEY, endpoint via
  * ASR_BASE_URL (e.g. https://whisper-api.myia.io/v1). Supports ogg/opus
  * directly (faster-whisper decodes natively).
+ *
+ * Retries up to 3 attempts on transient failures (network errors,
+ * 5xx server errors). Returns null on persistent failure or 4xx.
  */
 export async function transcribeAudioBuffer(
   buffer: Buffer,
@@ -55,42 +77,60 @@ export async function transcribeAudioBuffer(
   const config = loadConfig();
   if (!config) return null;
 
-  try {
-    const mime = mimeType || mimeForExt(extFromName(filename));
-    const form = new FormData();
-    form.append('file', new Blob([buffer], { type: mime }), filename);
-    form.append('model', config.model);
-    // language hint stops Whisper from misdetecting the language on short
-    // clips (auto-detection is unreliable below ~5s of speech).
-    if (config.language) form.append('language', config.language);
-    if (config.prompt) form.append('prompt', config.prompt);
+  const mime = mimeType || mimeForExt(extFromName(filename));
+  const url = `${config.baseUrl}/audio/transcriptions`;
 
-    const url = `${config.baseUrl}/audio/transcriptions`;
-    const resp = await fetch(url, {
-      method: 'POST',
-      headers: { Authorization: `Bearer ${config.apiKey}` },
-      body: form,
-    });
+  for (let attempt = 1; attempt <= TRANSCRIBE_MAX_ATTEMPTS; attempt++) {
+    try {
+      const resp = await fetch(url, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${config.apiKey}` },
+        body: buildTranscribeForm(buffer, filename, mime, config),
+      });
 
-    if (!resp.ok) {
+      if (resp.ok) {
+        const data = (await resp.json()) as { text?: string };
+        const text = (data.text || '').trim();
+        if (!text) {
+          log.debug('Transcription returned empty text', { filename });
+          return null;
+        }
+        if (attempt > 1) {
+          log.info('Transcribed voice message (after retry)', { filename, chars: text.length, attempt });
+        } else {
+          log.info('Transcribed voice message', { filename, chars: text.length });
+        }
+        return text;
+      }
+
       const body = await resp.text().catch(() => '');
-      log.warn('Transcription request failed', { status: resp.status, body: body.slice(0, 200) });
+      const isTransient = resp.status >= 500 && resp.status < 600;
+      if (isTransient && attempt < TRANSCRIBE_MAX_ATTEMPTS) {
+        const backoff = TRANSCRIBE_RETRY_BACKOFF_MS[attempt - 1];
+        log.warn('Transcription request failed (retrying)', {
+          status: resp.status,
+          attempt,
+          backoffMs: backoff,
+          body: body.slice(0, 200),
+        });
+        await new Promise((r) => setTimeout(r, backoff));
+        continue;
+      }
+      log.warn('Transcription request failed', { status: resp.status, attempt, body: body.slice(0, 200) });
+      return null;
+    } catch (err) {
+      // Network errors (TypeError "fetch failed", DNS, SSL handshake) — retry.
+      if (attempt < TRANSCRIBE_MAX_ATTEMPTS) {
+        const backoff = TRANSCRIBE_RETRY_BACKOFF_MS[attempt - 1];
+        log.warn('Transcription network error (retrying)', { filename, attempt, backoffMs: backoff, err });
+        await new Promise((r) => setTimeout(r, backoff));
+        continue;
+      }
+      log.error('Transcription error', { filename, attempt, err });
       return null;
     }
-
-    const data = (await resp.json()) as { text?: string };
-    const text = (data.text || '').trim();
-    if (!text) {
-      log.debug('Transcription returned empty text', { filename });
-      return null;
-    }
-
-    log.info('Transcribed voice message', { filename, chars: text.length });
-    return text;
-  } catch (err) {
-    log.error('Transcription error', { filename, err });
-    return null;
   }
+  return null;
 }
 
 function extFromName(name: string): string {


### PR DESCRIPTION
## Summary

Wrap the Whisper `/audio/transcriptions` call in a 3-attempt loop with backoff `[200ms, 600ms]`. Retries on transient failures, never on persistent ones.

**Retry conditions:**
- `TypeError: fetch failed` (network / SSL handshake / DNS)
- HTTP `5xx`

**No retry:**
- HTTP `4xx` (auth, malformed payload — wouldn't recover)

## Why

Observed 2026-05-10 in `nanoclaw.err.log`:
- 5× `Transcription error TypeError fetch failed` (19:19, 19:20, 14:08, 14:15, 17:15)
- 2× `Transcription request failed status=500 Internal Server Error` (11:39, 00:35)

Same endpoint produced **142 successful transcriptions** in `nanoclaw.out.log` on the same day (last at 20:28:13).

The drops are silent from the user's POV — no `🎤` echo, agent never sees `[Voice: ...]` inline → bot looks like it's ignoring voice messages. Two distinct intermittent modes:
1. **ARR po-2023 SSL chain instability** on `whisper-api.myia.io` — Node fetch fails sporadically depending on which CA chain it tries to verify against (PowerShell strict already fails systematically without `-SkipCertificateCheck`).
2. **Sporadic Whisper backend 500s** on po-2023 — server hiccup, recovers next call.

Both recover on a quick retry. Persistent outages still surface as `Transcription error attempt=3` after attempts are exhausted.

## Implementation note

`Blob` streams are single-use, so the `FormData` is rebuilt on each attempt via the `buildTranscribeForm` helper.

## Test plan

- [ ] Watch `logs/nanoclaw.err.log` for `Transcription network error (retrying) attempt=N` warnings
- [ ] Confirm transient failures are now followed by `Transcribed voice message (after retry)` instead of silent drop
- [ ] Persistent outages still surface as `Transcription error attempt=3` — make sure the failure mode escalates if Whisper goes fully down

PATCHES.md updated with PATCH #20 entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)