### PR TITLE
feat(scripts): persistent-data backup, restore & scheduled task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ store/
 data/
 logs/
 
+# Backup restore-validation scratch dir (scripts/restore.ts)
+.restore-verify/
+
 # Groups - per-installation state, not tracked
 groups/*
 

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -1,0 +1,119 @@
+# Backup & Restore — NanoClaw persistent data
+
+NanoClaw v2 keeps no state in a Docker volume. The host process spawns ephemeral
+per-session containers (`--rm`); everything that matters lives on the **host
+filesystem** under `data/` and `groups/`, plus the Claude Code harness memory in
+the user profile. The realistic loss vectors are an upstream sync clobbering
+install-specific files, an accidental `data/` deletion, disk failure on `D:`, or
+SQLite corruption — not a replaced volume.
+
+Tracked by [jsboige/nanoclaw#48](https://github.com/jsboige/nanoclaw/issues/48).
+Background incident: the 2026-05-14 Hermes total memory loss.
+
+## What is backed up
+
+| Path | What it is | Git? |
+|------|-----------|------|
+| `data/**/*.db` | Central `v2.db` + per-session `inbound.db` / `outbound.db` | no |
+| `data/*.json`, `data/restart-result.txt` | Runtime state files | no |
+| `.env` | Credential wiring | no |
+| `groups/` | Per-agent-group filesystem — minus `node_modules` and nested git repos (working *and* bare; those are reconstructible from their remote) | no |
+| `~/.claude/projects/d--nanoclaw/memory/` | Claude Code harness memory for this workspace | no |
+
+Each snapshot also contains a `manifest.json` (per-DB `integrity_check` result,
+file list, `ok` flag, timestamps).
+
+## Backup
+
+```bash
+pnpm exec tsx scripts/backup.ts
+```
+
+- DBs are copied with the SQLite **online-backup API** (`better-sqlite3`
+  `db.backup()`), never a raw copy of a live WAL file, then each copy is verified
+  with `PRAGMA integrity_check`.
+- Destination: `NANOCLAW_BACKUP_DIR` (default `E:\nanoclaw-backups` — on
+  `myia-ai-01`, disk 2, a separate physical NVMe from `D:` = disk 1).
+- Retention: keeps the most recent `NANOCLAW_BACKUP_KEEP` snapshots (default 7),
+  prunes older.
+- Exit code: `0` = all DBs passed integrity; `1` = at least one failed/errored.
+
+### Scheduled (automatic)
+
+`scripts/service/install-backup-task.ps1` registers the Windows Scheduled Task
+**`NanoClawBackup`** — daily at 04:17, running as the current user (Limited, no
+UAC). It calls `scripts/service/run-backup.ps1`, which logs to `logs/backup.log`
+and propagates the exit code to the task's `LastTaskResult`.
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File scripts/service/install-backup-task.ps1
+```
+
+Check health:
+
+```powershell
+Get-ScheduledTask -TaskName NanoClawBackup | Get-ScheduledTaskInfo |
+  Select-Object LastRunTime, LastTaskResult, NextRunTime   # LastTaskResult 0 = ok
+```
+
+## Validate a backup (non-destructive)
+
+Restores a snapshot into a scratch dir (`.restore-verify/`, git-ignored) and
+verifies every DB in the manifest is present and passes `integrity_check`, and
+every tree is present. Touches nothing in the live install.
+
+```bash
+pnpm exec tsx scripts/restore.ts                    # latest snapshot
+pnpm exec tsx scripts/restore.ts <snapshot-name>    # a specific one
+```
+
+Exit `0` = the snapshot is restorable and verified. Delete `.restore-verify/`
+afterwards (the script reminds you).
+
+## Restore (destructive — real recovery)
+
+> Restoring overwrites the live `data/` and `groups/`. The host service **must be
+> stopped first**, or the running container's open DB handles will fight the
+> restore and you'll get a corrupt mix.
+
+1. **Stop the service** (so nothing holds the session DBs open):
+   ```powershell
+   Start-Process nssm -ArgumentList stop,nanoclaw -Verb RunAs -Wait
+   ```
+2. **Pick and validate the snapshot** before trusting it:
+   ```bash
+   pnpm exec tsx scripts/restore.ts <snapshot-name>   # PASS in scratch first
+   ```
+3. **Restore into the repo root** — `--force` is required because the target is
+   the repo root:
+   ```bash
+   pnpm exec tsx scripts/restore.ts <snapshot-name> --into D:\nanoclaw --force
+   ```
+   This copies the snapshot's `data/`, `groups/`, `.env` and
+   `claude-harness-memory/` over the live tree, then re-runs `integrity_check` on
+   every restored DB.
+4. **Restore the harness memory** if needed — the snapshot's
+   `claude-harness-memory/` maps to `~/.claude/projects/d--nanoclaw/memory/`;
+   copy it back manually (it is outside the repo root).
+5. **Restart and verify**:
+   ```powershell
+   Start-Process nssm -ArgumentList start,nanoclaw -Verb RunAs -Wait
+   ```
+   Then confirm the central DB schema version and a Telegram round-trip:
+   ```bash
+   pnpm exec tsx scripts/q.ts data/v2.db "SELECT * FROM schema_version"
+   ```
+
+## Pre-upgrade safety gate (mandatory)
+
+Before any destructive operation — `git pull` / upstream sync (`/update-nanoclaw`),
+`./container/build.sh`, or a `data/` migration — take a fresh snapshot and
+confirm it:
+
+```bash
+pnpm exec tsx scripts/backup.ts && pnpm exec tsx scripts/restore.ts
+```
+
+Both must exit `0`. Note the snapshot name in the session / on
+`workspace-nanoclaw`. Only then proceed with the upgrade. This is the human gate
+that the Hermes incident skipped.

--- a/scripts/backup.ts
+++ b/scripts/backup.ts
@@ -1,0 +1,192 @@
+/**
+ * NanoClaw persistent-data backup.
+ *
+ * Snapshots the non-git, irreplaceable host-side state to an off-`D:\` location:
+ *   - every SQLite DB under data/  (central v2.db + per-session inbound/outbound)
+ *     via the SQLite online-backup API + PRAGMA integrity_check  — never a raw
+ *     copy of a live WAL file
+ *   - small data/ state files (.json) and .env
+ *   - groups/  minus node_modules and nested git repos (working *and* bare —
+ *     those are reconstructible from their remote)
+ *   - the Claude Code harness memory dir for this workspace
+ *
+ * Retention: keeps the most recent NANOCLAW_BACKUP_KEEP snapshots, prunes older.
+ *
+ * Run:   pnpm exec tsx scripts/backup.ts
+ * Dest:  $NANOCLAW_BACKUP_DIR  (default E:\nanoclaw-backups)
+ * Exit:  0 = all DBs passed integrity_check, 1 = at least one failed / errored.
+ *
+ * Tracked by jsboige/nanoclaw#48.
+ */
+import Database from 'better-sqlite3';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const REPO_ROOT = path.resolve(import.meta.dirname, '..');
+const BACKUP_BASE = process.env.NANOCLAW_BACKUP_DIR || 'E:\\nanoclaw-backups';
+const KEEP = Number(process.env.NANOCLAW_BACKUP_KEEP || 7);
+const MEMORY_DIR = path.join(
+  os.homedir(),
+  '.claude',
+  'projects',
+  'd--nanoclaw',
+  'memory',
+);
+
+const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+const dest = path.join(BACKUP_BASE, stamp);
+
+type DbResult = { src: string; bytes: number; integrity: string };
+type FileResult = { src: string; bytes: number };
+const dbResults: DbResult[] = [];
+const fileResults: FileResult[] = [];
+const errors: string[] = [];
+
+/** Recursively collect *.db files under a directory. */
+function findDbs(dir: string): string[] {
+  const out: string[] = [];
+  if (!fs.existsSync(dir)) return out;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...findDbs(full));
+    else if (entry.isFile() && entry.name.endsWith('.db')) out.push(full);
+  }
+  return out;
+}
+
+/** A dir is a git repo (skip it) if it has a .git, or is a bare repo. */
+function isGitRepo(dir: string): boolean {
+  if (fs.existsSync(path.join(dir, '.git'))) return true;
+  return (
+    fs.existsSync(path.join(dir, 'HEAD')) &&
+    fs.existsSync(path.join(dir, 'objects')) &&
+    fs.existsSync(path.join(dir, 'refs'))
+  );
+}
+
+async function backupDb(src: string): Promise<void> {
+  const rel = path.relative(REPO_ROOT, src);
+  const target = path.join(dest, rel);
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  try {
+    const db = new Database(src, { readonly: true });
+    try {
+      await db.backup(target);
+    } finally {
+      db.close();
+    }
+    const check = new Database(target, { readonly: true });
+    let integrity = 'unknown';
+    try {
+      integrity = (check.pragma('integrity_check', { simple: true }) as string) ?? 'unknown';
+    } finally {
+      check.close();
+    }
+    const bytes = fs.statSync(target).size;
+    dbResults.push({ src: rel, bytes, integrity });
+    if (integrity !== 'ok') errors.push(`integrity_check failed for ${rel}: ${integrity}`);
+  } catch (err) {
+    errors.push(`backup failed for ${rel}: ${(err as Error).message}`);
+  }
+}
+
+function copyFile(src: string): void {
+  if (!fs.existsSync(src)) return;
+  const rel = path.relative(REPO_ROOT, src);
+  const target = path.join(dest, rel);
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.copyFileSync(src, target);
+  fileResults.push({ src: rel, bytes: fs.statSync(target).size });
+}
+
+function copyTree(srcDir: string, label: string): void {
+  if (!fs.existsSync(srcDir)) return;
+  const target = path.join(dest, label);
+  let skipped = 0;
+  let copied = 0;
+  fs.cpSync(srcDir, target, {
+    recursive: true,
+    filter: (s) => {
+      const base = path.basename(s);
+      if (base === 'node_modules') {
+        skipped++;
+        return false;
+      }
+      if (fs.statSync(s).isDirectory() && s !== srcDir && isGitRepo(s)) {
+        skipped++;
+        return false;
+      }
+      if (fs.statSync(s).isFile()) copied++;
+      return true;
+    },
+  });
+  fileResults.push({ src: `${label}/ (tree, ${copied} files, ${skipped} dirs skipped)`, bytes: -1 });
+}
+
+async function main(): Promise<void> {
+  console.log(`[backup] NanoClaw → ${dest}`);
+  fs.mkdirSync(dest, { recursive: true });
+
+  // 1. SQLite DBs — online-backup API + integrity_check.
+  const dbs = findDbs(path.join(REPO_ROOT, 'data'));
+  for (const db of dbs) await backupDb(db);
+  console.log(`[backup] ${dbResults.length} SQLite DB(s) snapshotted`);
+
+  // 2. Small data/ state files + .env.
+  for (const f of ['data/circuit-breaker.json', 'data/roosync-inbox-processed.json', 'data/restart-result.txt', 'data/nanoclaw.db', '.env']) {
+    // data/nanoclaw.db handled by findDbs already; copyFile is idempotent-safe via overwrite — skip if already a *.db we backed up
+    if (f.endsWith('.db')) continue;
+    copyFile(path.join(REPO_ROOT, f));
+  }
+
+  // 3. groups/ minus node_modules + nested git repos.
+  copyTree(path.join(REPO_ROOT, 'groups'), 'groups');
+
+  // 4. Claude Code harness memory for this workspace.
+  copyTree(MEMORY_DIR, 'claude-harness-memory');
+
+  // 5. Manifest.
+  const manifest = {
+    tool: 'scripts/backup.ts',
+    issue: 'jsboige/nanoclaw#48',
+    createdAt: new Date().toISOString(),
+    host: os.hostname(),
+    repoRoot: REPO_ROOT,
+    dest,
+    databases: dbResults,
+    files: fileResults,
+    errors,
+    ok: errors.length === 0,
+  };
+  fs.writeFileSync(path.join(dest, 'manifest.json'), JSON.stringify(manifest, null, 2));
+
+  // 6. Retention — keep the most recent KEEP snapshots.
+  const snapshots = fs
+    .readdirSync(BACKUP_BASE, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name)
+    .sort();
+  const prune = snapshots.slice(0, Math.max(0, snapshots.length - KEEP));
+  for (const old of prune) {
+    fs.rmSync(path.join(BACKUP_BASE, old), { recursive: true, force: true });
+    console.log(`[backup] pruned old snapshot ${old}`);
+  }
+
+  // Summary.
+  const totalDbBytes = dbResults.reduce((n, r) => n + r.bytes, 0);
+  console.log(`[backup] DBs: ${dbResults.length} (${(totalDbBytes / 1024).toFixed(0)} KB), integrity: ${dbResults.every((r) => r.integrity === 'ok') ? 'all ok' : 'FAILURES'}`);
+  console.log(`[backup] files/trees: ${fileResults.length}`);
+  console.log(`[backup] retained snapshots: ${Math.min(snapshots.length, KEEP)} / KEEP=${KEEP}`);
+  if (errors.length) {
+    console.error(`[backup] ${errors.length} ERROR(S):`);
+    for (const e of errors) console.error(`  - ${e}`);
+    process.exit(1);
+  }
+  console.log('[backup] OK');
+}
+
+main().catch((err) => {
+  console.error(`[backup] FATAL: ${(err as Error).stack || err}`);
+  process.exit(1);
+});

--- a/scripts/restore.ts
+++ b/scripts/restore.ts
@@ -1,0 +1,141 @@
+/**
+ * NanoClaw persistent-data restore / backup-validation.
+ *
+ * Restores a snapshot produced by scripts/backup.ts into a target directory and
+ * verifies it: every DB in the snapshot's manifest is present and passes
+ * PRAGMA integrity_check, every tree is present.
+ *
+ * Default target is a scratch dir (`.restore-verify/`) so the snapshot can be
+ * validated WITHOUT touching the live install — this is the "validate the
+ * backup" path. To do a real restore, pass `--into <dir>`; restoring straight
+ * into the repo root is refused unless `--force` is also given (and the host
+ * service must be stopped first — see docs/backup-restore.md).
+ *
+ * Run:
+ *   pnpm exec tsx scripts/restore.ts                 # latest snapshot → .restore-verify/
+ *   pnpm exec tsx scripts/restore.ts <snapshot-name> # a specific snapshot
+ *   pnpm exec tsx scripts/restore.ts --into D:\path  # real restore target
+ *
+ * Exit: 0 = snapshot valid / restore verified, 1 = a check failed.
+ *
+ * Tracked by jsboige/nanoclaw#48.
+ */
+import Database from 'better-sqlite3';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const REPO_ROOT = path.resolve(import.meta.dirname, '..');
+const BACKUP_BASE = process.env.NANOCLAW_BACKUP_DIR || 'E:\\nanoclaw-backups';
+
+const args = process.argv.slice(2);
+const force = args.includes('--force');
+const intoIdx = args.indexOf('--into');
+const intoArg = intoIdx >= 0 ? args[intoIdx + 1] : undefined;
+const snapshotArg = args.find((a, i) => !a.startsWith('--') && i !== intoIdx + 1);
+
+function latestSnapshot(): string {
+  const dirs = fs
+    .readdirSync(BACKUP_BASE, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name)
+    .sort();
+  if (dirs.length === 0) throw new Error(`no snapshots under ${BACKUP_BASE}`);
+  return dirs[dirs.length - 1];
+}
+
+const snapshotName = snapshotArg || latestSnapshot();
+const snapshotDir = path.join(BACKUP_BASE, snapshotName);
+const target = path.resolve(intoArg || path.join(REPO_ROOT, '.restore-verify'));
+
+if (!fs.existsSync(snapshotDir)) {
+  console.error(`[restore] snapshot not found: ${snapshotDir}`);
+  process.exit(1);
+}
+if (target === REPO_ROOT && !force) {
+  console.error('[restore] refusing to restore into the repo root without --force');
+  console.error('[restore] stop the nanoclaw service first, then re-run with --force');
+  process.exit(1);
+}
+
+type Manifest = {
+  databases: { src: string; bytes: number; integrity: string }[];
+  files: { src: string; bytes: number }[];
+  ok: boolean;
+  createdAt: string;
+};
+
+const manifestPath = path.join(snapshotDir, 'manifest.json');
+if (!fs.existsSync(manifestPath)) {
+  console.error(`[restore] no manifest.json in ${snapshotDir}`);
+  process.exit(1);
+}
+const manifest: Manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+
+console.log(`[restore] snapshot : ${snapshotName} (created ${manifest.createdAt}, manifest.ok=${manifest.ok})`);
+console.log(`[restore] target   : ${target}`);
+
+const failures: string[] = [];
+
+// Copy the whole snapshot tree into target (skip the manifest itself).
+fs.mkdirSync(target, { recursive: true });
+for (const entry of fs.readdirSync(snapshotDir)) {
+  if (entry === 'manifest.json') continue;
+  fs.cpSync(path.join(snapshotDir, entry), path.join(target, entry), { recursive: true });
+}
+
+// Verify every DB from the manifest: present + integrity_check ok.
+let dbOk = 0;
+for (const db of manifest.databases) {
+  const restored = path.join(target, db.src);
+  if (!fs.existsSync(restored)) {
+    failures.push(`missing after restore: ${db.src}`);
+    continue;
+  }
+  try {
+    const conn = new Database(restored, { readonly: true });
+    let integrity = 'unknown';
+    let tables = 0;
+    try {
+      integrity = (conn.pragma('integrity_check', { simple: true }) as string) ?? 'unknown';
+      tables = (
+        conn.prepare("SELECT count(*) AS n FROM sqlite_master WHERE type='table'").get() as { n: number }
+      ).n;
+    } finally {
+      conn.close();
+    }
+    if (integrity === 'ok') {
+      dbOk++;
+      console.log(`[restore]   ok  ${db.src} (${tables} tables)`);
+    } else {
+      failures.push(`integrity_check=${integrity} for ${db.src}`);
+    }
+  } catch (err) {
+    failures.push(`cannot open restored ${db.src}: ${(err as Error).message}`);
+  }
+}
+
+// Verify every file / tree from the manifest is present.
+let fileOk = 0;
+for (const f of manifest.files) {
+  // tree entries look like "groups/ (tree, N files, M dirs skipped)"
+  const name = f.src.replace(/\\/g, '/').split(' ')[0].replace(/\/$/, '');
+  const restored = path.join(target, name);
+  if (fs.existsSync(restored)) {
+    fileOk++;
+  } else {
+    failures.push(`missing after restore: ${f.src}`);
+  }
+}
+
+console.log(`[restore] DBs verified : ${dbOk}/${manifest.databases.length}`);
+console.log(`[restore] files/trees  : ${fileOk}/${manifest.files.length}`);
+
+if (failures.length) {
+  console.error(`[restore] ${failures.length} FAILURE(S):`);
+  for (const f of failures) console.error(`  - ${f}`);
+  process.exit(1);
+}
+console.log(`[restore] PASS — snapshot ${snapshotName} is restorable and verified`);
+if (target.endsWith('.restore-verify')) {
+  console.log('[restore] (scratch verify dir left in place — safe to delete)');
+}

--- a/scripts/service/install-backup-task.ps1
+++ b/scripts/service/install-backup-task.ps1
@@ -1,0 +1,66 @@
+# Register (or re-register) the NanoClaw persistent-data backup as a Windows
+# Scheduled Task: daily snapshot of data/ + groups/ + harness memory to an
+# off-D:\ location (see scripts/backup.ts).
+#
+# Runs under the CURRENT user session (Limited / no UAC) — same principal as
+# NanoClawRooSyncInboxWatcher, so it can read the user's profile memory dir.
+#
+# Usage:
+#   powershell -NoProfile -ExecutionPolicy Bypass -File install-backup-task.ps1
+#
+# Tracked by jsboige/nanoclaw#48.
+
+$ErrorActionPreference = 'Stop'
+
+$TaskName = 'NanoClawBackup'
+$ScriptDir = $PSScriptRoot
+$Launcher = Join-Path $ScriptDir 'run-backup.ps1'
+
+if (-not (Test-Path $Launcher)) {
+    Write-Error "Launcher not found: $Launcher"
+    exit 1
+}
+
+$Action = New-ScheduledTaskAction `
+    -Execute 'powershell.exe' `
+    -Argument "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$Launcher`""
+
+# Daily at 04:17 (off-peak, off the :00 mark). StartWhenAvailable catches up a
+# missed run if the machine was off at 04:17.
+$Trigger = New-ScheduledTaskTrigger -Daily -At '04:17'
+
+$Settings = New-ScheduledTaskSettingsSet `
+    -AllowStartIfOnBatteries `
+    -DontStopIfGoingOnBatteries `
+    -StartWhenAvailable `
+    -RestartCount 2 `
+    -RestartInterval (New-TimeSpan -Minutes 5) `
+    -ExecutionTimeLimit (New-TimeSpan -Hours 1)
+
+$Principal = New-ScheduledTaskPrincipal `
+    -UserId "$env:USERDOMAIN\$env:USERNAME" `
+    -LogonType Interactive `
+    -RunLevel Limited
+
+$existing = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+if ($existing) {
+    Write-Host "[install-backup-task] Removing existing task '$TaskName'"
+    Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false
+}
+
+Write-Host "[install-backup-task] Registering task '$TaskName' for user $env:USERDOMAIN\$env:USERNAME (daily 04:17)"
+Register-ScheduledTask `
+    -TaskName $TaskName `
+    -Action $Action `
+    -Trigger $Trigger `
+    -Settings $Settings `
+    -Principal $Principal `
+    -Description 'NanoClaw persistent-data backup — daily SQLite-safe snapshot of data/ + groups/ + harness memory to off-D:\ (jsboige/nanoclaw#48)' | Out-Null
+
+Write-Host "[install-backup-task] Task registered. Running it once now to verify."
+Start-ScheduledTask -TaskName $TaskName
+
+Start-Sleep -Seconds 8
+$info = Get-ScheduledTask -TaskName $TaskName | Get-ScheduledTaskInfo
+$state = (Get-ScheduledTask -TaskName $TaskName).State
+Write-Host "[install-backup-task] State: $state | LastRunTime: $($info.LastRunTime) | LastTaskResult: $($info.LastTaskResult) (0 = success)"

--- a/scripts/service/run-backup.ps1
+++ b/scripts/service/run-backup.ps1
@@ -1,0 +1,37 @@
+# NanoClaw persistent-data backup launcher (Scheduled Task action).
+#
+# cd to the repo root, run scripts/backup.ts via the in-tree tsx, append output
+# to logs/backup.log. Exit code is propagated so the Scheduled Task's
+# LastTaskResult reflects backup integrity (0 = ok, 1 = a DB failed/errored).
+#
+# Tracked by jsboige/nanoclaw#48.
+
+$ErrorActionPreference = 'Stop'
+
+$RootDir = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$Tsx = Join-Path $RootDir 'node_modules\.bin\tsx.cmd'
+$Entry = Join-Path $RootDir 'scripts\backup.ts'
+$LogDir = Join-Path $RootDir 'logs'
+$LogFile = Join-Path $LogDir 'backup.log'
+
+if (-not (Test-Path $LogDir)) {
+    New-Item -ItemType Directory -Path $LogDir -Force | Out-Null
+}
+
+Set-Location $RootDir
+
+$stamp = (Get-Date).ToString('o')
+"[run-backup] $stamp starting (pid $PID)" | Out-File -FilePath $LogFile -Append -Encoding utf8
+
+if (-not (Test-Path $Tsx)) {
+    "[run-backup] ERROR: tsx not found at $Tsx — run pnpm install" | Out-File -FilePath $LogFile -Append -Encoding utf8
+    exit 1
+}
+
+# Out-File -Encoding utf8: PowerShell 5.1's `*>>` defaults to UTF-16LE on FR
+# locale, which makes the log unreadable to grep/tail.
+& $Tsx $Entry 2>&1 | Out-File -FilePath $LogFile -Append -Encoding utf8
+$code = $LASTEXITCODE
+
+"[run-backup] finished, exit=$code" | Out-File -FilePath $LogFile -Append -Encoding utf8
+exit $code


### PR DESCRIPTION
## Summary

NanoClaw v2 keeps **no state in a Docker volume** — the host filesystem (`data/`,
`groups/`) plus the Claude Code harness memory dir are the persistence surface.
There was no backup, no restore path, and no pre-upgrade safety gate. The
2026-05-14 **Hermes total memory loss** (its Docker volume was replaced during a
rebuild with no snapshot) is the motivating incident.

This PR adds the backup/restore tooling tracked by #48.

### What's included

- **`scripts/backup.ts`** — SQLite **online-backup API** (`better-sqlite3`
  `db.backup()`) + `PRAGMA integrity_check` for every DB under `data/` (never a
  raw copy of a live WAL file). Also copies `data/` state files, `.env`,
  `groups/` (minus `node_modules` and nested git repos — working *and* bare,
  since those are reconstructible from their remote: 545 MB raw → 77 MB snapshot)
  and the harness memory dir. Writes a `manifest.json`. Retention keeps the last
  `NANOCLAW_BACKUP_KEEP` snapshots (default 7). Dest = `NANOCLAW_BACKUP_DIR`
  (default `E:\nanoclaw-backups`).
- **`scripts/restore.ts`** — restores a snapshot into a scratch dir (default,
  non-destructive — this is the "validate the backup" path) or a real target
  (`--into`; repo root requires `--force`). Verifies every DB `integrity_check`
  and every tree from the manifest.
- **`scripts/service/run-backup.ps1`** + **`install-backup-task.ps1`** — Windows
  Scheduled Task `NanoClawBackup`, daily 04:17, current-user principal (Limited,
  no UAC), logs to `logs/backup.log`, propagates exit code to `LastTaskResult`.
- **`docs/backup-restore.md`** — backup / validate / restore runbook + the
  mandatory pre-upgrade safety gate.
- **`.gitignore`** — ignore the `.restore-verify/` scratch dir.

## Test plan

Verified on `myia-ai-01` (2026-05-14):

- `pnpm exec tsx scripts/backup.ts` → 6 DBs, `integrity_check` ok on all, 77.3 MB,
  1.4 s; `manifest.json` `ok: true`.
- Scheduled task registered and triggered once → `State: Ready`,
  `LastTaskResult: 0`; second snapshot written; retention counter `2 / 7`;
  `logs/backup.log` clean.
- `pnpm exec tsx scripts/restore.ts` → restore-to-scratch **PASS**, 6/6 DBs
  `integrity_check` ok, 6/6 trees present.
- Data fidelity: restored `v2.db` row counts (`users`, `agent_groups`,
  `messaging_groups`, `user_roles`, `messaging_group_agents`, `sessions`) match
  the live DB exactly; restored session `inbound.db` holds 2328 `messages_in`.
- `npx tsc --noEmit` clean.

## Notes

- Not yet done (tracked in #48): the destructive end-to-end restore drill
  (stop service → restore into root → restart), and wiring the pre-upgrade gate
  into the `/update-nanoclaw` skill.
- Generic tooling only — no installation-specific files included.

Refs #48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
