### PR TITLE
fix(host-sweep): PATCH #34 - auto-advance recurring tasks past MAX_TRIES

### DIFF
--- a/PATCHES.md
+++ b/PATCHES.md
@@ -227,6 +227,14 @@ If none works, document the patch here with justification.
 - **Exit condition:** Either (a) upstream adopts retry-with-backoff for the container runtime probe (we should file an issue/PR), or (b) the host gains a "degraded mode" where channel adapters keep running for inbound buffering while the runtime is unreachable. Until then, this patch is the right shape: don't conflate a transient pipe failure with "Docker not installed".
 - **Lines:** ~50 (function rewrite + caller `await` + 4 vitest cases including the hiccup-recovery path).
 
+### 34. Auto-advance recurring tasks past MAX_TRIES failure (sweep safety net)
+
+- **File:** `src/host-sweep.ts` (`resetStuckProcessingRows` — call new helper inside the `tries >= MAX_TRIES` branch before `markMessageFailed`; functions and test helper made `async` to allow the dynamic import in the same style as `handleRecurrence`); `src/modules/scheduling/recurrence.ts` (new `advanceRecurringTaskAfterFailure` exported alongside `handleRecurrence`).
+- **Summary:** When a `messages_in` row carrying a cron `recurrence` is about to be sealed as `failed` after MAX_TRIES (transient stall / session-invalid / OneCLI cascade), enqueue the next series instance via the same `cron-parser + insertRecurrence + clearRecurrence` flow used by `handleRecurrence`. The failed row keeps `status='failed'` (with `recurrence` cleared) for audit; the new pending row carries the series forward with the same `series_id`. Pre-fix path: `handleRecurrence` only ever picks up `status='completed' AND recurrence IS NOT NULL`, so once a row was marked failed the cron series was silently dead — no operator alert, no next instance. Post-fix: a single chain-flap cascade no longer kills the series.
+- **Why:** Reproduced 2026-05-28 with the ClusterManager `15 8-22 * * *` and `30 8-22 * * *` review crons on the `main` agent group. Stall retries (PATCH #26 `stalledAborted` flagging) exhausted MAX_TRIES around 10:00Z, both rows were marked `failed`, then `handleRecurrence` skipped them forever. The bot went silent on its review schedule for ~3h before the user noticed. Manual recovery had to flip the rows back to `completed` so the recurrence engine would re-pick them up — not scalable. The safety net moves recovery into the sweep itself.
+- **Exit condition:** Upstream changes the recurrence engine to also pick up `status='failed' AND recurrence IS NOT NULL`, or removes the dual-status filter entirely.
+- **Lines:** ~60 host (helper + import + 1 call-site wrap + async signature plumbing) + ~140 tests (6 helper cases in `recurrence.test.ts` + 1 integration case in `host-sweep.test.ts`).
+
 ### 33. Runtime-path OneCLI / Docker transient retry (extends #22 intent)
 
 - **File:** `src/container-runtime.ts` (new `retryOnTransientRuntimeError` helper + `isTransientRuntimeError` + `TRANSIENT_ERROR_MARKERS` constant); `src/container-runner.ts` (wraps the two OneCLI calls — `ensureAgent` and `applyContainerConfig` — at spawn time).

--- a/container/agent-runner/src/integration.test.ts
+++ b/container/agent-runner/src/integration.test.ts
@@ -368,10 +368,10 @@ describe('poll loop — stale session recovery', () => {
     await waitFor(() => getUndeliveredMessages().length > 0, 2000);
     controller.abort();
 
-    // Error was written to outbound
+    // Error was written to outbound (PATCH #31 changed from 'Error:' to 'Transient session error')
     const out = getUndeliveredMessages();
     expect(out).toHaveLength(1);
-    expect(JSON.parse(out[0].content).text).toContain('Error:');
+    expect(JSON.parse(out[0].content).text).toContain('Transient session error');
 
     // Continuation was cleared (isSessionInvalid returned true)
     expect(getContinuation('mock')).toBeUndefined();

--- a/src/host-sweep.test.ts
+++ b/src/host-sweep.test.ts
@@ -343,24 +343,25 @@ describe('resetStuckProcessingRows — orphan claim cleanup', () => {
     await _resetStuckProcessingRowsForTesting(inDb, outDb, fakeSession(), 'claim-stuck');
 
     // The failed row is sealed for audit and its recurrence is cleared.
-    const failed = inDb
-      .prepare('SELECT status, recurrence FROM messages_in WHERE id = ?')
-      .get('task-recur') as { status: string; recurrence: string | null };
+    const failed = inDb.prepare('SELECT status, recurrence FROM messages_in WHERE id = ?').get('task-recur') as {
+      status: string;
+      recurrence: string | null;
+    };
     expect(failed.status).toBe('failed');
     expect(failed.recurrence).toBeNull();
 
     // The series carries forward as a new pending row with same recurrence.
     const carry = inDb
-      .prepare(
-        "SELECT id, status, recurrence, series_id, process_after FROM messages_in WHERE id != 'task-recur'",
-      )
-      .get() as {
-      id: string;
-      status: string;
-      recurrence: string | null;
-      series_id: string;
-      process_after: string;
-    } | undefined;
+      .prepare("SELECT id, status, recurrence, series_id, process_after FROM messages_in WHERE id != 'task-recur'")
+      .get() as
+      | {
+          id: string;
+          status: string;
+          recurrence: string | null;
+          series_id: string;
+          process_after: string;
+        }
+      | undefined;
     expect(carry).toBeDefined();
     expect(carry!.status).toBe('pending');
     expect(carry!.recurrence).toBe('15 8-22 * * *');

--- a/src/host-sweep.test.ts
+++ b/src/host-sweep.test.ts
@@ -267,7 +267,7 @@ describe('deleteOrphanProcessingClaims', () => {
 });
 
 describe('resetStuckProcessingRows — orphan claim cleanup', () => {
-  it('deletes orphan processing_ack rows so next sweep tick does not see them', () => {
+  it('deletes orphan processing_ack rows so next sweep tick does not see them', async () => {
     const { inDb, outDb } = makeSessionDbs();
     const claimedAt = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(); // 2h ago
 
@@ -284,7 +284,7 @@ describe('resetStuckProcessingRows — orphan claim cleanup', () => {
     // Sanity: the orphan claim is what would trip claim-stuck.
     expect(getProcessingClaims(outDb)).toHaveLength(1);
 
-    _resetStuckProcessingRowsForTesting(inDb, outDb, fakeSession(), 'absolute-ceiling');
+    await _resetStuckProcessingRowsForTesting(inDb, outDb, fakeSession(), 'absolute-ceiling');
 
     // Regression assertion: orphan claim is gone — next sweep tick will see
     // an empty claims list and not kill the freshly respawned container.
@@ -301,7 +301,7 @@ describe('resetStuckProcessingRows — orphan claim cleanup', () => {
     expect(row.process_after).not.toBeNull();
   });
 
-  it('still clears orphan claims even when the inbound message has already been retried (skip path)', () => {
+  it('still clears orphan claims even when the inbound message has already been retried (skip path)', async () => {
     // Edge case: the inbound row was already rescheduled (process_after in
     // future), so the per-message retry loop skips it. The orphan in
     // processing_ack must still be removed — otherwise the bug remains.
@@ -316,11 +316,56 @@ describe('resetStuckProcessingRows — orphan claim cleanup', () => {
       .run(claimedAt, future);
     outDb.prepare("INSERT INTO processing_ack VALUES ('m-2', 'processing', ?)").run(claimedAt);
 
-    _resetStuckProcessingRowsForTesting(inDb, outDb, fakeSession(), 'claim-stuck');
+    await _resetStuckProcessingRowsForTesting(inDb, outDb, fakeSession(), 'claim-stuck');
 
     expect(getProcessingClaims(outDb)).toEqual([]);
     const row = inDb.prepare('SELECT tries FROM messages_in WHERE id = ?').get('m-2') as { tries: number };
     expect(row.tries).toBe(1); // not bumped, the skip path held
+  });
+
+  // Regression: 2026-05-28 ClusterManager cron series silent for ~3h. Stall
+  // retries hit MAX_TRIES=5, row was marked 'failed', handleRecurrence's
+  // `status='completed'` filter then skipped it forever — series dead. The
+  // safety net advances the recurrence before sealing the failure.
+  it('auto-advances a recurring task when it hits MAX_TRIES instead of silently killing the series', async () => {
+    const { inDb, outDb } = makeSessionDbs();
+    const claimedAt = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+
+    // Recurring task row at MAX_TRIES, still pending, same shape as the
+    // production ClusterManager rows (`15 8-22 * * *`).
+    inDb
+      .prepare(
+        "INSERT INTO messages_in (id, seq, kind, timestamp, status, tries, recurrence, series_id, content) VALUES ('task-recur', 1, 'task', ?, 'pending', 5, '15 8-22 * * *', 'task-recur', '{}')",
+      )
+      .run(claimedAt);
+    outDb.prepare("INSERT INTO processing_ack VALUES ('task-recur', 'processing', ?)").run(claimedAt);
+
+    await _resetStuckProcessingRowsForTesting(inDb, outDb, fakeSession(), 'claim-stuck');
+
+    // The failed row is sealed for audit and its recurrence is cleared.
+    const failed = inDb
+      .prepare('SELECT status, recurrence FROM messages_in WHERE id = ?')
+      .get('task-recur') as { status: string; recurrence: string | null };
+    expect(failed.status).toBe('failed');
+    expect(failed.recurrence).toBeNull();
+
+    // The series carries forward as a new pending row with same recurrence.
+    const carry = inDb
+      .prepare(
+        "SELECT id, status, recurrence, series_id, process_after FROM messages_in WHERE id != 'task-recur'",
+      )
+      .get() as {
+      id: string;
+      status: string;
+      recurrence: string | null;
+      series_id: string;
+      process_after: string;
+    } | undefined;
+    expect(carry).toBeDefined();
+    expect(carry!.status).toBe('pending');
+    expect(carry!.recurrence).toBe('15 8-22 * * *');
+    expect(carry!.series_id).toBe('task-recur');
+    expect(new Date(carry!.process_after).getTime()).toBeGreaterThan(Date.now());
   });
 });
 

--- a/src/host-sweep.ts
+++ b/src/host-sweep.ts
@@ -372,9 +372,7 @@ async function resetStuckProcessingRows(
       // the audit trail is intact either way.
       // MODULE-HOOK:scheduling-recurrence-failure:start
       try {
-        const { advanceRecurringTaskAfterFailure } = await import(
-          './modules/scheduling/recurrence.js'
-        );
+        const { advanceRecurringTaskAfterFailure } = await import('./modules/scheduling/recurrence.js');
         await advanceRecurringTaskAfterFailure(inDb, msg.id, session);
       } catch (err) {
         log.error('Auto-advance threw while handling MAX_TRIES failure', {

--- a/src/host-sweep.ts
+++ b/src/host-sweep.ts
@@ -263,7 +263,7 @@ async function sweepSession(session: Session): Promise<void> {
 
     // 3. Running-container SLA: absolute ceiling + per-claim stuck rules.
     if (alive && outDb) {
-      enforceRunningContainerSla(inDb, outDb, session, agentGroup.id);
+      await enforceRunningContainerSla(inDb, outDb, session, agentGroup.id);
     }
 
     // 4. Crashed-container cleanup: processing rows left behind get retried.
@@ -271,7 +271,7 @@ async function sweepSession(session: Session): Promise<void> {
     // or wake failed). resetStuckProcessingRows itself is idempotent — it
     // skips messages already scheduled for a future retry.
     if (!alive && outDb) {
-      resetStuckProcessingRows(inDb, outDb, session, 'container not running');
+      await resetStuckProcessingRows(inDb, outDb, session, 'container not running');
     }
 
     // 5. Recurrence fanout for completed recurring tasks.
@@ -299,12 +299,12 @@ function declaredToolTimeoutMs(state: ContainerState | null): number | null {
   return typeof state.tool_declared_timeout_ms === 'number' ? state.tool_declared_timeout_ms : null;
 }
 
-function enforceRunningContainerSla(
+async function enforceRunningContainerSla(
   inDb: Database.Database,
   outDb: Database.Database,
   session: Session,
   agentGroupId: string,
-): void {
+): Promise<void> {
   const decision = decideStuckAction({
     now: Date.now(),
     heartbeatMtimeMs: heartbeatMtimeMs(agentGroupId, session.id),
@@ -322,7 +322,7 @@ function enforceRunningContainerSla(
       ceilingMs: decision.ceilingMs,
     });
     killContainer(session.id, 'absolute-ceiling');
-    resetStuckProcessingRows(inDb, outDb, session, 'absolute-ceiling');
+    await resetStuckProcessingRows(inDb, outDb, session, 'absolute-ceiling');
     return;
   }
 
@@ -333,25 +333,25 @@ function enforceRunningContainerSla(
     toleranceMs: decision.toleranceMs,
   });
   killContainer(session.id, 'claim-stuck');
-  resetStuckProcessingRows(inDb, outDb, session, 'claim-stuck');
+  await resetStuckProcessingRows(inDb, outDb, session, 'claim-stuck');
 }
 
-export function _resetStuckProcessingRowsForTesting(
+export async function _resetStuckProcessingRowsForTesting(
   inDb: Database.Database,
   outDb: Database.Database,
   session: Session,
   reason: string,
-): void {
-  resetStuckProcessingRows(inDb, outDb, session, reason, outDb);
+): Promise<void> {
+  await resetStuckProcessingRows(inDb, outDb, session, reason, outDb);
 }
 
-function resetStuckProcessingRows(
+async function resetStuckProcessingRows(
   inDb: Database.Database,
   outDb: Database.Database,
   session: Session,
   reason: string,
   writableOutDb?: Database.Database,
-): void {
+): Promise<void> {
   const claims = getProcessingClaims(outDb);
   const now = Date.now();
   for (const { message_id } of claims) {
@@ -364,6 +364,27 @@ function resetStuckProcessingRows(
     if (msg.processAfter && parseSqliteUtc(msg.processAfter) > now) continue;
 
     if (msg.tries >= MAX_TRIES) {
+      // Recurring-task safety net: if this failing message carries a cron
+      // recurrence, enqueue the next instance before sealing this row as
+      // failed. Without this, a chain-flap cascade (stalls, session-invalid,
+      // OneCLI hiccups) silently kills the cron series — no next row is ever
+      // produced. Failure is best-effort; markMessageFailed still runs so
+      // the audit trail is intact either way.
+      // MODULE-HOOK:scheduling-recurrence-failure:start
+      try {
+        const { advanceRecurringTaskAfterFailure } = await import(
+          './modules/scheduling/recurrence.js'
+        );
+        await advanceRecurringTaskAfterFailure(inDb, msg.id, session);
+      } catch (err) {
+        log.error('Auto-advance threw while handling MAX_TRIES failure', {
+          messageId: msg.id,
+          sessionId: session.id,
+          err,
+        });
+      }
+      // MODULE-HOOK:scheduling-recurrence-failure:end
+
       markMessageFailed(inDb, msg.id);
       log.warn('Message marked as failed after max retries', {
         messageId: msg.id,

--- a/src/modules/scheduling/recurrence.test.ts
+++ b/src/modules/scheduling/recurrence.test.ts
@@ -13,7 +13,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 import { ensureSchema, openInboundDb } from '../../db/session-db.js';
 import { insertTask } from './db.js';
-import { handleRecurrence } from './recurrence.js';
+import { advanceRecurringTaskAfterFailure, handleRecurrence } from './recurrence.js';
 import type { Session } from '../../types.js';
 
 // Per-process tmp dir avoids EPERM under Windows when sibling test files hold
@@ -150,5 +150,162 @@ describe('handleRecurrence', () => {
 
     const count = (db.prepare(`SELECT COUNT(*) AS c FROM messages_in`).get() as { c: number }).c;
     expect(count).toBe(1);
+  });
+});
+
+describe('advanceRecurringTaskAfterFailure', () => {
+  // Regression: 2026-05-28. ClusterManager cron series `15 8-22 * * *` and
+  // `30 8-22 * * *` both went silent after their `messages_in` rows hit
+  // status='failed' with tries=5 from stall retries. handleRecurrence's
+  // `status='completed'` filter skipped them forever — series dead. The
+  // safety net advances the series even when the row failed.
+
+  it('enqueues next instance and clears recurrence on the failed row', async () => {
+    const db = freshDb();
+    insertTask(db, {
+      id: 'task-fail',
+      processAfter: '2026-05-28T13:15:00.000Z',
+      recurrence: '15 8-22 * * *',
+      platformId: 'tg-123',
+      channelType: 'telegram',
+      threadId: null,
+      content: JSON.stringify({ prompt: 'cron review' }),
+    });
+    db.prepare(`UPDATE messages_in SET status='failed', tries=5 WHERE id='task-fail'`).run();
+
+    const result = await advanceRecurringTaskAfterFailure(db, 'task-fail', fakeSession());
+
+    expect(result).toBe(true);
+
+    const rows = db
+      .prepare(`SELECT id, status, process_after, recurrence, series_id FROM messages_in ORDER BY seq`)
+      .all() as Array<{
+      id: string;
+      status: string;
+      process_after: string;
+      recurrence: string | null;
+      series_id: string;
+    }>;
+    expect(rows).toHaveLength(2);
+
+    const failed = rows.find((r) => r.id === 'task-fail')!;
+    const next = rows.find((r) => r.id !== 'task-fail')!;
+
+    // Failed row keeps status='failed' for audit; recurrence cleared so the
+    // safety net + handleRecurrence both skip it on future ticks.
+    expect(failed.status).toBe('failed');
+    expect(failed.recurrence).toBeNull();
+
+    // Next instance carries the series forward, pending, with same cron.
+    expect(next.status).toBe('pending');
+    expect(next.recurrence).toBe('15 8-22 * * *');
+    expect(next.series_id).toBe('task-fail');
+    expect(new Date(next.process_after).getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it('preserves platform routing fields on the cloned row', async () => {
+    const db = freshDb();
+    insertTask(db, {
+      id: 'task-route',
+      processAfter: '2026-05-28T13:30:00.000Z',
+      recurrence: '30 8-22 * * *',
+      platformId: 'slack-C0',
+      channelType: 'slack',
+      threadId: 'thread-99',
+      content: JSON.stringify({ prompt: 'second cron' }),
+    });
+    db.prepare(`UPDATE messages_in SET status='failed', tries=5 WHERE id='task-route'`).run();
+
+    await advanceRecurringTaskAfterFailure(db, 'task-route', fakeSession());
+
+    const next = db
+      .prepare(`SELECT platform_id, channel_type, thread_id, content FROM messages_in WHERE id != 'task-route'`)
+      .get() as {
+      platform_id: string;
+      channel_type: string;
+      thread_id: string;
+      content: string;
+    };
+    expect(next.platform_id).toBe('slack-C0');
+    expect(next.channel_type).toBe('slack');
+    expect(next.thread_id).toBe('thread-99');
+    expect(JSON.parse(next.content)).toEqual({ prompt: 'second cron' });
+  });
+
+  it('returns false when message id does not exist', async () => {
+    const db = freshDb();
+    const result = await advanceRecurringTaskAfterFailure(db, 'nope', fakeSession());
+    expect(result).toBe(false);
+    const count = (db.prepare(`SELECT COUNT(*) AS c FROM messages_in`).get() as { c: number }).c;
+    expect(count).toBe(0);
+  });
+
+  it('returns false and does not clone when row has no recurrence', async () => {
+    const db = freshDb();
+    insertTask(db, {
+      id: 'task-oneshot',
+      processAfter: '2026-05-28T13:00:00.000Z',
+      recurrence: null,
+      platformId: null,
+      channelType: null,
+      threadId: null,
+      content: JSON.stringify({ prompt: 'one-shot' }),
+    });
+    db.prepare(`UPDATE messages_in SET status='failed', tries=5 WHERE id='task-oneshot'`).run();
+
+    const result = await advanceRecurringTaskAfterFailure(db, 'task-oneshot', fakeSession());
+
+    expect(result).toBe(false);
+    const count = (db.prepare(`SELECT COUNT(*) AS c FROM messages_in`).get() as { c: number }).c;
+    expect(count).toBe(1);
+  });
+
+  it('clears recurrence on malformed cron (no infinite re-error from safety net)', async () => {
+    const db = freshDb();
+    insertTask(db, {
+      id: 'task-badcron',
+      processAfter: '2026-05-28T13:00:00.000Z',
+      recurrence: '0 21-5 * * *', // invalid range, repro from Apr 30
+      platformId: null,
+      channelType: null,
+      threadId: null,
+      content: JSON.stringify({ prompt: 'night shift' }),
+    });
+    db.prepare(`UPDATE messages_in SET status='failed', tries=5 WHERE id='task-badcron'`).run();
+
+    const result = await advanceRecurringTaskAfterFailure(db, 'task-badcron', fakeSession());
+
+    expect(result).toBe(false);
+    const row = db.prepare(`SELECT recurrence FROM messages_in WHERE id='task-badcron'`).get() as {
+      recurrence: string | null;
+    };
+    expect(row.recurrence).toBeNull();
+
+    // No clone produced for unparseable cron.
+    const count = (db.prepare(`SELECT COUNT(*) AS c FROM messages_in`).get() as { c: number }).c;
+    expect(count).toBe(1);
+  });
+
+  it('is idempotent — second call on the same failed id is a no-op (recurrence already cleared)', async () => {
+    const db = freshDb();
+    insertTask(db, {
+      id: 'task-idem',
+      processAfter: '2026-05-28T13:00:00.000Z',
+      recurrence: '0 9 * * *',
+      platformId: null,
+      channelType: null,
+      threadId: null,
+      content: JSON.stringify({ prompt: 'idempotent' }),
+    });
+    db.prepare(`UPDATE messages_in SET status='failed', tries=5 WHERE id='task-idem'`).run();
+
+    await advanceRecurringTaskAfterFailure(db, 'task-idem', fakeSession());
+    const countAfterFirst = (db.prepare(`SELECT COUNT(*) AS c FROM messages_in`).get() as { c: number }).c;
+    expect(countAfterFirst).toBe(2);
+
+    const result = await advanceRecurringTaskAfterFailure(db, 'task-idem', fakeSession());
+    expect(result).toBe(false);
+    const countAfterSecond = (db.prepare(`SELECT COUNT(*) AS c FROM messages_in`).get() as { c: number }).c;
+    expect(countAfterSecond).toBe(2);
   });
 });

--- a/src/modules/scheduling/recurrence.ts
+++ b/src/modules/scheduling/recurrence.ts
@@ -16,7 +16,7 @@ import type Database from 'better-sqlite3';
 import { TIMEZONE } from '../../config.js';
 import { log } from '../../log.js';
 import type { Session } from '../../types.js';
-import { clearRecurrence, getCompletedRecurring, insertRecurrence } from './db.js';
+import { clearRecurrence, getCompletedRecurring, insertRecurrence, type RecurringMessage } from './db.js';
 
 export async function handleRecurrence(inDb: Database.Database, session: Session): Promise<void> {
   const recurring = getCompletedRecurring(inDb);
@@ -62,5 +62,65 @@ export async function handleRecurrence(inDb: Database.Database, session: Session
         err,
       });
     }
+  }
+}
+
+/**
+ * Auto-advance a recurring task after MAX_TRIES failure.
+ *
+ * Mirrors handleRecurrence but operates on a single message id regardless of
+ * status. Without this, a transient failure cascade (5 stalls,
+ * session-invalid hits, OneCLI hiccups) silently kills the cron series: the
+ * row gets status='failed', handleRecurrence's `status='completed'` filter
+ * skips it, no next instance is ever enqueued, and the bot goes quiet
+ * indefinitely. Reproduced 2026-05-28 with two ClusterManager cron series
+ * (`15 8-22 * * *` + `30 8-22 * * *`) both flat-lined for ~3h after stall
+ * retries exhausted.
+ *
+ * Returns true if a next instance was enqueued, false otherwise. Errors are
+ * logged, never thrown — the caller's markMessageFailed must still run.
+ */
+export async function advanceRecurringTaskAfterFailure(
+  inDb: Database.Database,
+  messageId: string,
+  session: Session,
+): Promise<boolean> {
+  const msg = inDb
+    .prepare("SELECT * FROM messages_in WHERE id = ? AND kind = 'task' AND recurrence IS NOT NULL AND recurrence != ''")
+    .get(messageId) as RecurringMessage | undefined;
+  if (!msg) return false;
+
+  try {
+    const { CronExpressionParser } = await import('cron-parser');
+    const interval = CronExpressionParser.parse(msg.recurrence, { tz: TIMEZONE });
+    const nextRun = interval.next().toISOString();
+    const newId = `task-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+    insertRecurrence(inDb, msg, newId, nextRun);
+    clearRecurrence(inDb, msg.id);
+
+    log.warn('Auto-advanced recurring task after MAX_TRIES failure', {
+      failedId: msg.id,
+      newId,
+      seriesId: msg.series_id,
+      nextRun,
+      sessionId: session.id,
+    });
+    return true;
+  } catch (err) {
+    try {
+      clearRecurrence(inDb, msg.id);
+    } catch (clearErr) {
+      log.error('Failed to clear recurrence after MAX_TRIES failure advance error', {
+        messageId: msg.id,
+        err: clearErr,
+      });
+    }
+    log.error('Failed to advance recurring task after MAX_TRIES failure', {
+      messageId: msg.id,
+      recurrence: msg.recurrence,
+      err,
+    });
+    return false;
   }
 }


### PR DESCRIPTION
## Summary

- Recurring `messages_in` rows that hit `MAX_TRIES` (5 retries during stalls / processing_ack timeouts) used to get sealed with `status='failed'`. The recurrence handler only re-enqueues rows where `status='completed'` — so a failed row never produces a next instance, and the whole cron series silently dies.
- `resetStuckProcessingRows` now calls a new `advanceRecurringTaskAfterFailure` helper just before `markMessageFailed`. The helper mirrors `handleRecurrence` but runs against a single row regardless of status: it parses the cron in `TIMEZONE`, inserts the next pending row with the same `series_id`, then clears the recurrence on the failed row (so it's never re-cloned). Errors are caught and logged — `markMessageFailed` still runs.
- Failed row keeps audit trail (`status='failed'`, `recurrence=NULL`). The series carries forward.

## Why

2026-05-28 incident: ClusterManager Telegram bot went silent for ~3h. Two cron series — `15 8-22 * * *` and `30 8-22 * * *` — both had their last `messages_in` row flat-line at `status='failed', tries=5` after a stall cascade earlier in the day. `handleRecurrence` skipped them forever. Manual recovery via SQL re-armed both series; this patch makes the recovery automatic.

Reaches the same exit condition as a `[completed]` row would: a fresh pending row with `series_id` preserved, cron carried forward, scheduled at the next valid `cron.next()` in the configured timezone.

## Test plan

- [x] `pnpm test -- src/modules/scheduling/recurrence.test.ts` — 9 tests pass (3 existing + 6 new for `advanceRecurringTaskAfterFailure`: happy path, route field preservation, missing id, no-recurrence row, malformed cron, idempotency)
- [x] `pnpm test -- src/host-sweep.test.ts` — 18 tests pass including new integration test that drives a row through the MAX_TRIES branch and asserts both the sealed-failed audit row and the carry-forward pending row
- [x] `pnpm run build` — clean
- [x] Deployed on myia-ai-01 (host service restarted). Sweep tick logged `Inserted next recurrence` for the live ClusterManager series after restart.

## Files

| File | Change |
|------|--------|
| `src/modules/scheduling/recurrence.ts` | New `advanceRecurringTaskAfterFailure` helper |
| `src/host-sweep.ts` | Hook the helper into `resetStuckProcessingRows` MAX_TRIES branch via `MODULE-HOOK:scheduling-recurrence-failure`; turn `enforceRunningContainerSla` + `resetStuckProcessingRows` async |
| `src/modules/scheduling/recurrence.test.ts` | 6 new helper unit tests |
| `src/host-sweep.test.ts` | 1 new integration test + async-aware updates to existing tests |
| `PATCHES.md` | Document PATCH #34 |

## Notes

- Overlay patch (PATCHES.md updated). No upstream submission planned at this time — the recurrence engine lives in the modules branch that gets installed per-fork, so this is a fork-resilience improvement rather than an upstream bug.
- `Co-Authored-By` on commits per the AI-assisted convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)