### PR TITLE
fix(container-runner): PATCH #38 + #39 (env passthrough + NO_PROXY) + MCP recovery tooling

### DIFF
--- a/PATCHES.md
+++ b/PATCHES.md
@@ -383,6 +383,14 @@ If none works, document the patch here with justification.
 - **Exit condition:** Upstream adds a generic `container.json:env` passthrough field (same exit as patch #1), or wires the compaction host→container override itself.
 - **Lines:** ~5
 
+### 39. Exempt internal hosts from the OneCLI HTTPS proxy (`NO_PROXY`)
+
+- **File:** `src/container-runner.ts` (`buildContainerArgs`, immediately after `onecli.applyContainerConfig` succeeds and before the `--entrypoint` push).
+- **Summary:** Push `-e NO_PROXY=host.docker.internal,localhost,127.0.0.1` (+ lowercase `no_proxy`) so the credential proxy that OneCLI injects (`HTTP(S)_PROXY=…@host.docker.internal:10255` + `NODE_USE_ENV_PROXY=1`) does **not** capture traffic to the host's own internal services. Set after `applyContainerConfig` so it wins over any earlier value; both cases are set because some clients read only the lowercase form.
+- **Why:** v2.1.17 bumped the OneCLI SDK 0.5→2.2, which started injecting `HTTP(S)_PROXY` + `NODE_USE_ENV_PROXY=1` into the agent container so its *external* API calls get vault credential injection. But it sets no `NO_PROXY`, so the agent's *internal* MCP traffic to `host.docker.internal:9090` (the TBXark proxy carrying its own `MCP_PROXY_BEARER` — see patch #2 bypass) was also forced through the credential proxy, which 401s/refuses it. Result: `npx mcp-remote` / the SDK fetch returns `fetch failed` → `FATAL: required MCP server(s) unreachable: roo-state-manager … sk-agent` → the container exits non-zero and the host respawns it every ~60s. Crash-loop hammered the API and (via reset-to-pending review tasks picked up by overlapping respawns) produced byte-identical duplicate PR reviews off the `:15/:45` cadence. Diagnosed 2026-06-23 with an in-container MCP probe: proxy on → `fetch failed`; proxy on **+ NO_PROXY** → HTTP 200, 15 RSM tools + 13 sk-agent tools. After the fix the bot resumed real work (9 PRs at 11:01Z) and the crash-loop stopped. Mirrors the `NO_PROXY: host.docker.internal` the ollama/opencode provider skills already document.
+- **Exit condition:** Upstream sets a sane `NO_PROXY` when it injects the OneCLI proxy env (so internal `host.docker.internal` MCP/loopback traffic bypasses the credential proxy by default), or OneCLI's `applyContainerConfig` grows a no-proxy allowlist parameter.
+- **Lines:** ~6 (+ comment block)
+
 ---
 
 ## Removed / not needed under v2

--- a/PATCHES.md
+++ b/PATCHES.md
@@ -374,6 +374,15 @@ If none works, document the patch here with justification.
 - **Plan:** Implement as container skill `container/skills/voice-transcription/` that the agent invokes on audio content. Agent script fetches the voice file via Telegram Bot API, POSTs to `ASR_BASE_URL` (Whisper), receives text. No patch to the Telegram adapter.
 - **Env vars:** `ASR_BASE_URL`, `ASR_API_KEY` already passed through via patch #1.
 
+### 38. Forward `CLAUDE_CODE_AUTO_COMPACT_WINDOW` host env into container
+
+- **Commit:** _(this change)_
+- **File:** `src/container-runner.ts` (`buildContainerArgs`, right after the bare-`GH_TOKEN` special-case).
+- **Summary:** Single-var `-e CLAUDE_CODE_AUTO_COMPACT_WINDOW=<host value>` forward, gated on the var being present in the host env. Sibling of patch #1 — that one only forwards the `ANTHROPIC_/GH_TOKEN_/MCP_/ASR_/LOCAL_*` prefixes; `CLAUDE_*` is deliberately not a prefix, so this targeted forward avoids leaking the `settings.json`-managed `CLAUDE_CODE_*` flags.
+- **Why:** `container/agent-runner/src/providers/claude.ts` reads `CLAUDE_CODE_AUTO_COMPACT_WINDOW` from its own `process.env` (default `'165000'`) to set the Claude Code auto-compaction threshold, and its comment documents an *"operator override: set CLAUDE_CODE_AUTO_COMPACT_WINDOW in the host env … useful when running with a 1M-context model variant"*. That override never reached the container because patch #1's prefix list doesn't cover `CLAUDE_*`. Needed to cap condensation at **250k** on `glm-5.2` (1M context) without using the full 1M. Set in `.env`: `CLAUDE_CODE_AUTO_COMPACT_WINDOW=250000`.
+- **Exit condition:** Upstream adds a generic `container.json:env` passthrough field (same exit as patch #1), or wires the compaction host→container override itself.
+- **Lines:** ~5
+
 ---
 
 ## Removed / not needed under v2

--- a/PATCHES.md
+++ b/PATCHES.md
@@ -376,7 +376,7 @@ If none works, document the patch here with justification.
 
 ### 38. Forward `CLAUDE_CODE_AUTO_COMPACT_WINDOW` host env into container
 
-- **Commit:** _(this change)_
+- **Commit:** `a4b88be` (PR #55)
 - **File:** `src/container-runner.ts` (`buildContainerArgs`, right after the bare-`GH_TOKEN` special-case).
 - **Summary:** Single-var `-e CLAUDE_CODE_AUTO_COMPACT_WINDOW=<host value>` forward, gated on the var being present in the host env. Sibling of patch #1 — that one only forwards the `ANTHROPIC_/GH_TOKEN_/MCP_/ASR_/LOCAL_*` prefixes; `CLAUDE_*` is deliberately not a prefix, so this targeted forward avoids leaking the `settings.json`-managed `CLAUDE_CODE_*` flags.
 - **Why:** `container/agent-runner/src/providers/claude.ts` reads `CLAUDE_CODE_AUTO_COMPACT_WINDOW` from its own `process.env` (default `'165000'`) to set the Claude Code auto-compaction threshold, and its comment documents an *"operator override: set CLAUDE_CODE_AUTO_COMPACT_WINDOW in the host env … useful when running with a 1M-context model variant"*. That override never reached the container because patch #1's prefix list doesn't cover `CLAUDE_*`. Needed to cap condensation at **250k** on `glm-5.2` (1M context) without using the full 1M. Set in `.env`: `CLAUDE_CODE_AUTO_COMPACT_WINDOW=250000`.

--- a/scripts/bypass-mcp-edge.ts
+++ b/scripts/bypass-mcp-edge.ts
@@ -1,0 +1,74 @@
+/**
+ * One-shot patch: point the ClusterManager bot's MCP servers (roo-state-manager,
+ * sk-agent) directly at the local TBXark proxy (myia-mcp-proxy, published on
+ * 0.0.0.0:9090 on this host) instead of through the public HTTPS edge
+ * https://mcp-tools.myia.io.
+ *
+ * Why: 2026-06-21 myia-po-2023 crashed, taking down the IIS ARR reverse proxy
+ * that fronts mcp-tools.myia.io. The actual MCP backend (TBXark) runs locally on
+ * ai-01 and is healthy — the bot was just routing ai-01 -> po-2023 -> back to
+ * ai-01:9090, an absurd round-trip through a dead hop. Going direct via
+ * host.docker.internal:9090 keeps BOTH servers and the same bearer, drops the
+ * dead edge, and incidentally sidesteps the TLS layer entirely (loopback HTTP).
+ *
+ * Hermes (po-2026) already connects straight to ai-01:9090 — same pattern.
+ *
+ * Bearer is unchanged: MCP_PROXY_BEARER == TBXark authToken (ad28ecc7…), which
+ * TBXark accepts directly on :9090 (verified: POST initialize -> HTTP 200).
+ *
+ * Usage:
+ *   pnpm exec tsx scripts/bypass-mcp-edge.ts            # apply bypass
+ *   pnpm exec tsx scripts/bypass-mcp-edge.ts --revert   # restore edge URL
+ *
+ * After running, restart the bot so the container respawns with the new config:
+ *   ncl groups restart --id ag-1776992584813-k3oj0w
+ *   (or Stop-Service / Start-Service nanoclaw)
+ */
+import Database from 'better-sqlite3';
+import path from 'node:path';
+
+const AG_ID = 'ag-1776992584813-k3oj0w';
+const EDGE = 'https://mcp-tools.myia.io';
+const DIRECT = 'http://host.docker.internal:9090';
+
+const revert = process.argv.includes('--revert');
+const [from, to] = revert ? [DIRECT, EDGE] : [EDGE, DIRECT];
+
+const dbPath = path.resolve('data/v2.db');
+const db = new Database(dbPath);
+
+const row = db
+  .prepare('SELECT mcp_servers FROM container_configs WHERE agent_group_id = ?')
+  .get(AG_ID) as { mcp_servers: string } | undefined;
+if (!row) throw new Error(`No container_configs row for ${AG_ID}`);
+
+if (!row.mcp_servers.includes(from)) {
+  console.log(
+    `No-op: "${from}" not present in mcp_servers (already ${revert ? 'reverted' : 'bypassed'}?).`,
+  );
+  console.log('CURRENT:', row.mcp_servers);
+  db.close();
+  process.exit(0);
+}
+
+const cfg = JSON.parse(row.mcp_servers) as Record<
+  string,
+  { command: string; args: string[]; env?: Record<string, string>; timeout?: number }
+>;
+
+for (const name of Object.keys(cfg)) {
+  cfg[name].args = cfg[name].args.map((a) => a.replace(from, to));
+  const url = cfg[name].args.find((a) => a.includes('/mcp'));
+  console.log(`${revert ? 'reverted' : 'bypassed'} ${name}: ${url}`);
+}
+
+const newJson = JSON.stringify(cfg);
+db.prepare(
+  'UPDATE container_configs SET mcp_servers = ?, updated_at = ? WHERE agent_group_id = ?',
+).run(newJson, new Date().toISOString(), AG_ID);
+
+const after = db
+  .prepare('SELECT mcp_servers FROM container_configs WHERE agent_group_id = ?')
+  .get(AG_ID) as { mcp_servers: string };
+console.log('AFTER:', after.mcp_servers);
+db.close();

--- a/scripts/watchdog-tbxark.ps1
+++ b/scripts/watchdog-tbxark.ps1
@@ -1,0 +1,164 @@
+# watchdog-tbxark.ps1 — Probe TBXark MCP proxy *end-to-end* and restart if the
+# roo-state-manager (RSM) backend is dead, not just the HTTP front door.
+#
+# Why a full handshake instead of a simple ping:
+#   TBXark (myia-mcp-proxy) answers `initialize` with HTTP 200 from its own HTTP
+#   layer even when the upstream RSM backend (sparfenyuk -> node -> GoogleDriveFS)
+#   has died or gone stale. The RSM node child restarts independently of TBXark;
+#   when it does, TBXark keeps a stale upstream session and silently serves a
+#   dead backend. A bare `initialize` 200 check is blind to this — bots then see
+#   "roo-state-manager down" every cron cycle while the watchdog logs "OK".
+#
+#   So this probe drives the real MCP handshake (initialize -> Mcp-Session-Id ->
+#   tools/list) and requires tools/list to return > 0 tools. If TBXark answers
+#   but RSM serves no tools, the upstream session is stale -> restart TBXark
+#   (which re-pairs all upstream sessions). Same remedy if TBXark itself is dead.
+#
+# A cooldown ($CooldownMinutes) prevents restart storms when the backend is
+# genuinely down (vs. merely stale): one restart fixes the stale case; if it's
+# still down after a restart we back off instead of looping every 5 minutes.
+#
+# Scheduled via Windows Task Scheduler. Typical: every 5 minutes.
+
+$ErrorActionPreference = 'Stop'
+$ProxyPort = 9090
+$ContainerName = 'myia-mcp-proxy'
+$LogFile = 'D:\nanoclaw\logs\watchdog-tbxark.log'
+$CooldownFile = 'D:\nanoclaw\logs\.tbxark-last-restart'
+$CooldownMinutes = 20
+# Probe the deepest/slowest backend; if RSM is healthy the shallow ones are too.
+$ProbeServer = 'roo-state-manager'
+
+# Auth token: TBXark's mcpProxy.options.authTokens[0]. It rotates, so read it
+# from the live config and fall back to the last-known value if unreadable.
+$AuthToken = 'ad28ecc74e0963765de2e69d2f75bb542b3b65e378c9b306e8eeeeb98b15906b'
+$cfgPath = 'D:\roo-extensions\docker\mcp-proxy\config.json'
+if (Test-Path $cfgPath) {
+    try {
+        $cfg = Get-Content $cfgPath -Raw | ConvertFrom-Json
+        $t = $cfg.mcpProxy.options.authTokens[0]
+        if ($t) { $AuthToken = $t }
+    } catch { }
+}
+
+function Write-Log($msg) {
+    $ts = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+    $line = "[$ts] $msg"
+    Add-Content -Path $LogFile -Value $line -Encoding UTF8
+    Write-Output $line
+}
+
+# Full MCP handshake against one server through TBXark.
+# Returns @{ httpOk = <bool>; toolsOk = <bool>; tools = <int>; detail = <str> }
+#   httpOk  : TBXark's HTTP layer answered initialize (front door alive)
+#   toolsOk : tools/list returned > 0 tools (backend actually serving)
+function Test-McpBackend($server) {
+    $uri = "http://127.0.0.1:${ProxyPort}/$server/mcp"
+    $accept = 'application/json, text/event-stream'
+    $initBody = '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"watchdog","version":"2.0"}}}'
+
+    # 1) initialize -> capture Mcp-Session-Id
+    try {
+        $h = @{ 'Authorization' = "Bearer $AuthToken"; 'Content-Type' = 'application/json'; 'Accept' = $accept }
+        $r1 = Invoke-WebRequest -Uri $uri -Method POST -Headers $h -Body $initBody -TimeoutSec 15 -UseBasicParsing
+    }
+    catch {
+        $status = $_.Exception.Response.StatusCode.value__
+        return @{ httpOk = $false; toolsOk = $false; tools = 0; detail = "initialize failed (HTTP $status / $($_.Exception.Message))" }
+    }
+
+    # TBXark serves tools/list statelessly for these servers — it does NOT
+    # return an Mcp-Session-Id on initialize and does NOT require one on
+    # tools/list. So the session id is optional: forward it only if present,
+    # and judge health purely on whether tools/list returns tools.
+    $sid = $null
+    if ($r1.Headers['Mcp-Session-Id']) { $sid = @($r1.Headers['Mcp-Session-Id'])[0] }
+
+    # 2) tools/list (carry the session id only if TBXark gave us one)
+    try {
+        $h2 = @{ 'Authorization' = "Bearer $AuthToken"; 'Content-Type' = 'application/json'; 'Accept' = $accept }
+        if ($sid) { $h2['Mcp-Session-Id'] = $sid }
+        $listBody = '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
+        $r2 = Invoke-WebRequest -Uri $uri -Method POST -Headers $h2 -Body $listBody -TimeoutSec 25 -UseBasicParsing
+    }
+    catch {
+        $status = $_.Exception.Response.StatusCode.value__
+        return @{ httpOk = $true; toolsOk = $false; tools = 0; detail = "tools/list failed (HTTP $status / $($_.Exception.Message))" }
+    }
+
+    # Response may be plain JSON or an SSE 'data: {...}' event.
+    $content = $r2.Content
+    $obj = $null
+    try {
+        if ($content -match 'data:\s*(\{[\s\S]*\})\s*$') {
+            $obj = $Matches[1] | ConvertFrom-Json
+        } else {
+            $obj = $content | ConvertFrom-Json
+        }
+    } catch {
+        return @{ httpOk = $true; toolsOk = $false; tools = 0; detail = 'tools/list returned unparseable body' }
+    }
+
+    $tools = @($obj.result.tools).Count
+    return @{ httpOk = $true; toolsOk = ($tools -gt 0); tools = $tools; detail = "$tools tools" }
+}
+
+function Restart-Tbxark($reason) {
+    # Cooldown guard — avoid restart storms when the backend is genuinely down.
+    if (Test-Path $CooldownFile) {
+        try {
+            $last = [datetime]::Parse((Get-Content $CooldownFile -Raw).Trim())
+            $age = (Get-Date) - $last
+            if ($age.TotalMinutes -lt $CooldownMinutes) {
+                Write-Log "WARN: $reason — restart suppressed (last restart $([int]$age.TotalMinutes)m ago < ${CooldownMinutes}m cooldown)"
+                return
+            }
+        } catch { }
+    }
+
+    Write-Log "WARN: $reason — force-restarting $ContainerName"
+    docker kill $ContainerName 2>$null | Out-Null
+    Start-Sleep -Seconds 3
+    docker start $ContainerName 2>$null
+    if ($LASTEXITCODE -eq 0) {
+        (Get-Date).ToString('o') | Set-Content -Path $CooldownFile -Encoding UTF8 -NoNewline
+        Write-Log "OK: Restarted $ContainerName. Waiting 8s for upstreams to re-pair..."
+        Start-Sleep -Seconds 8
+        $verify = Test-McpBackend $ProbeServer
+        if ($verify.toolsOk) {
+            Write-Log "OK: Post-restart RSM healthy ($($verify.tools) tools)."
+        } else {
+            Write-Log "ERROR: Post-restart RSM still unhealthy ($($verify.detail)). Backend may be genuinely down."
+        }
+    } else {
+        Write-Log "ERROR: Failed to restart $ContainerName."
+    }
+}
+
+try {
+    # Is the container running at all?
+    $state = docker inspect $ContainerName --format '{{.State.Status}}' 2>$null
+    if ($LASTEXITCODE -ne 0 -or $state -ne 'running') {
+        Write-Log "WARN: Container $ContainerName not running (state=$state). Starting..."
+        docker start $ContainerName 2>$null
+        if ($LASTEXITCODE -eq 0) { Write-Log "OK: Container started." } else { Write-Log "ERROR: Failed to start container." }
+        exit 0
+    }
+
+    # End-to-end RSM probe.
+    $probe = Test-McpBackend $ProbeServer
+    if ($probe.toolsOk) {
+        Write-Log "OK: RSM healthy via TBXark ($($probe.detail))"
+        exit 0
+    }
+
+    if (-not $probe.httpOk) {
+        Restart-Tbxark "TBXark front door down ($($probe.detail))"
+    } else {
+        # The exact silent-failure mode the old watchdog missed.
+        Restart-Tbxark "TBXark up but RSM backend stale/dead ($($probe.detail))"
+    }
+}
+catch {
+    Write-Log "ERROR: Unhandled exception: $($_.Exception.Message)"
+}

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -503,6 +503,18 @@ async function buildContainerArgs(
     args.push('-e', `GH_TOKEN=${ghTokenDefault}`);
   }
 
+  // [PATCH-myia #38] Forward the documented auto-compaction override into the
+  // container. The agent-runner reads CLAUDE_CODE_AUTO_COMPACT_WINDOW from its
+  // process.env (container/agent-runner/src/providers/claude.ts) — but the
+  // ENV_PASSTHROUGH_PREFIXES above don't cover CLAUDE_*, so the operator
+  // override the claude.ts comment promises never reached the container. We
+  // wire this one specific var explicitly (not the broad CLAUDE_CODE_ prefix,
+  // which would also forward settings.json-managed flags). Used to cap
+  // condensation at 250k on the 1M-context glm-5.2 without using the full 1M.
+  if (process.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW) {
+    args.push('-e', `CLAUDE_CODE_AUTO_COMPACT_WINDOW=${process.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW}`);
+  }
+
   // Provider-contributed env vars (e.g. XDG_DATA_HOME, OPENCODE_*, NO_PROXY).
   if (providerContribution.env) {
     for (const [key, value] of Object.entries(providerContribution.env)) {

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -578,6 +578,28 @@ async function buildContainerArgs(
   }
   log.info('OneCLI gateway applied', { containerName });
 
+  // [PATCH-myia #39] Exempt internal hosts from the OneCLI HTTPS proxy.
+  // onecli.applyContainerConfig (above) injects HTTP(S)_PROXY=…@host.docker.internal:10255
+  // + NODE_USE_ENV_PROXY=1 so the agent's *external* API calls are routed
+  // through the vault for credential injection — but it sets no NO_PROXY. So
+  // traffic to the host's *internal* services is also forced through the
+  // credential proxy, which 401s / refuses it. The big casualty is the
+  // roo-state-manager + sk-agent MCP at host.docker.internal:9090 (PATCHES.md#2
+  // bypass): it carries its own MCP_PROXY_BEARER and must NOT be proxied. With
+  // the proxy in front of it, `npx mcp-remote` / the SDK's fetch get
+  // "fetch failed" → "required MCP server(s) unreachable" → bot crash-loop.
+  // Internal traffic never needs OneCLI credentials, so exempt it. Mirrors what
+  // the ollama/opencode providers already contribute for themselves (see
+  // .claude/skills/add-ollama-provider). Pushed AFTER applyContainerConfig so it
+  // wins over any earlier NO_PROXY; both cases set since some clients (and the
+  // lowercase-only `no_proxy` readers) check only one form. Regressed with the
+  // v2.1.17 OneCLI SDK 0.5→2.2 bump, which started injecting the proxy env.
+  {
+    const noProxy = 'host.docker.internal,localhost,127.0.0.1';
+    args.push('-e', `NO_PROXY=${noProxy}`);
+    args.push('-e', `no_proxy=${noProxy}`);
+  }
+
   // Override entrypoint: run v2 entry point directly via Bun (no tsc, no stdin).
   args.push('--entrypoint', 'bash');
 


### PR DESCRIPTION
## Summary

Overlay branch bundling two `container-runner` env fixes plus the MCP-chain recovery tooling developed during the 2026-06-22/23 incident window. Per-patch commits are kept atomic (no squash) so `PATCHES.md` commit references stay valid.

### PATCH #38 — forward `CLAUDE_CODE_AUTO_COMPACT_WINDOW` (`a4b88be`)
`container/agent-runner/src/providers/claude.ts` reads `CLAUDE_CODE_AUTO_COMPACT_WINDOW` (default `165000`) to set the auto-compaction threshold, with a documented host-env operator override — but the host `ENV_PASSTHROUGH_PREFIXES` (`[PATCH-myia #1]`) only covers `ANTHROPIC_/GH_TOKEN_/MCP_/ASR_/LOCAL_*`, not `CLAUDE_*`. This forwards the one specific var (not the broad `CLAUDE_CODE_` prefix), gated on presence. Needed to cap condensation at **250k** on `glm-5.2` (1M context).

### PATCH #39 — exempt internal hosts from the OneCLI proxy (`36c01fe`)
v2.1.17's OneCLI SDK 0.5→2.2 bump injects `HTTP(S)_PROXY=…@host.docker.internal:10255` + `NODE_USE_ENV_PROXY=1` so the agent's **external** API calls get vault credential injection — but sets no `NO_PROXY`. That forced the agent's **internal** MCP traffic to `host.docker.internal:9090` (TBXark proxy, carrying its own `MCP_PROXY_BEARER`) through the credential proxy, which 401s it → `fetch failed` → `FATAL: required MCP server(s) unreachable: roo-state-manager, sk-agent` → container exits → host respawns every ~60s. The crash-loop hammered the API and, via reset-to-pending review tasks picked up by overlapping respawns, produced byte-identical duplicate PR reviews off the `:15/:45` cron cadence.

Fix: push `-e NO_PROXY/no_proxy=host.docker.internal,localhost,127.0.0.1` after `applyContainerConfig`. **Verified in-container:** proxy on → `fetch failed`; proxy on **+ NO_PROXY** → HTTP 200, 15 RSM + 13 sk-agent tools. Bot resumed real work (9 PRs at 11:01Z) and the crash-loop stopped. Mirrors the `NO_PROXY: host.docker.internal` the ollama/opencode provider skills already document. **Upstream candidate** — real OneCLI-integration regression affecting any install using OneCLI + `host.docker.internal` MCP servers.

### Recovery tooling (install-specific, fork-only)
- `scripts/bypass-mcp-edge.ts` (`1dffb0a`) — points the bot's MCP config directly at TBXark `host.docker.internal:9090` when the `mcp-tools.myia.io` edge is down (po-2023 crash); `--revert` restores.
- `scripts/watchdog-tbxark.ps1` (`84d351f`) — hardened: full MCP handshake (initialize → tools/list, require >0 tools) against roo-state-manager instead of just pinging the HTTP front door. Auto-restarts TBXark (`docker kill`+`start`) only when RSM serves 0 tools, with a 20-min cooldown. Verified: continuous `OK: RSM healthy (15 tools)` every 5 min, zero spurious restarts.

## Verification

- `pnpm run build` clean; `dist/container-runner.js` contains both forwards.
- Live `docker inspect`: `ANTHROPIC_MODEL=glm-5.2`, `CLAUDE_CODE_AUTO_COMPACT_WINDOW=250000`, `NO_PROXY=host.docker.internal,localhost,127.0.0.1` all present.
- In-container MCP probe (real env): roo-state-manager 200/15 tools, sk-agent 200/13 tools.

## Notes

- Tracked as `[PATCH-myia #38]` and `[PATCH-myia #39]` in `PATCHES.md`, each with exit conditions.
- Host-side only — no image rebuild required.
- `.env` changes (model + 250k value) are local/gitignored, not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)