### PR TITLE
chore(scripts): commit accumulated cluster recovery/operational tooling

### DIFF
--- a/hermes-recovery-2026-05-14.md
+++ b/hermes-recovery-2026-05-14.md
@@ -1,0 +1,218 @@
+# Hermes memory-loss recovery — gathered material (2026-05-14)
+
+> Working artifact. Compiled by Claude Code (myia-ai-01:nanoclaw) in response to
+> jsboige's request after Hermes lost all persistent data during the 2026-05-14
+> upstream-sync rebuild (Docker volume replaced without snapshot).
+>
+> Sources crossed: nanoclaw workspace dashboard + archives, cluster-coordination
+> dashboard + archive `2026-05-14T13-02-25`, Telegram inbound history
+> (`data/v2-sessions/ag-1776992584813-k3oj0w/sess-1776993077016-7qx60e/inbound.db`,
+> 651 chat messages 2026-04-24 → 2026-05-14), local memory file
+> `reference_hermes_onboarding.md`, GitHub issues.
+
+## 1. The incident
+
+- **What:** 2026-05-14 upstream sync + container rebuild of Hermes ran without a
+  volume snapshot. The original `hermes` Docker volume was replaced → total loss
+  of sessions, cron jobs, `SOUL.md` persona, learned protocols, bot memory.
+- **Still intact:** `hermes-dashboard` container (bind mount `/home/jesse/.hermes`)
+  — only 1 session / 4 messages, a lightweight separate instance, not the main bot.
+- **Status:** Hermes container stopped, awaiting backup procedure (#2) before
+  restoration (#1).
+
+### Issues filed by the hermes-agent Claude Code agent
+
+| Repo | # | Title |
+|------|---|-------|
+| jsboige/hermes-agent | 1 | Restore Bot Memory & Knowledge Base |
+| jsboige/hermes-agent | 2 | Volume Backup & Restore Procedure |
+| jsboige/roo-extensions | 2168 | Hermes: Restore Bot Memory & Knowledge Base (mirror) |
+| jsboige/roo-extensions | 2169 | Hermes: Volume Backup & Restore Procedure (mirror) |
+
+Dashboard posts: `[ASK]` on `workspace-nanoclaw` (2026-05-14T14:06Z) and `[ALERT]`
+on `workspace-cluster-coordination` (2026-05-14T14:06Z) — both call NanoClaw a
+primary reconstruction source.
+
+## 2. Identities & cluster map
+
+| Attribute | NanoClaw | Hermes |
+|-----------|----------|--------|
+| Host machine | `myia-ai-01` (Win11, 3× RTX 4090) | `myia-po-2026` |
+| Claude Code workspace | `D:\nanoclaw` (`nanoclaw`) | `C:\dev\hermes-agent` (`c--dev-hermes-agent`) |
+| Repo | `jsboige/nanoclaw` (fork of `qwibitai/nanoclaw`) | `jsboige/hermes-agent` |
+| Telegram bot | `@NanoClawClusterBot` ("NanoClaw Cluster Manager") | `@MyIAHermesBot` |
+| Dashboard identity | `cluster-manager:nanoclaw-cluster` | `myia-po-2026:hermes-agent` |
+| Coordinator role | **Rapporteur** (fixed) | **Secrétaire** (fixed) |
+
+Cluster = 6 machines: `myia-ai-01`, `myia-po-2023`, `myia-po-2024`, `myia-po-2025`,
+`myia-po-2026` (Hermes host), `web1`. Operator = **Emerjesse** = jsboige (French,
+talks to both bots in one Telegram group "Cluster Coordination" + DMs).
+
+Official repos under cluster review: CoursIA, roo-extensions, mcp-servers,
+Epita-IS (`jsboigeEpita/2025-Epita-Intelligence-Symbolique`), Argumentum,
+nanoclaw, hermes-agent.
+
+Both bots run on **GLM (z.ai)**, `/api/coding/paas/v4`. `glm-4.5-flash` was removed
+2026-05-14 → use `glm-5-turbo` for compression. Available: glm-4.5, glm-4.5-air,
+glm-4.6, glm-4.7, glm-5, glm-5-turbo, glm-5.1. z.ai economy budget ≈ 5h/day.
+Shared GitHub token `clusterManager-Myia` / `GH_TOKEN_CLUSTERMANAGER` (= jsboige) —
+cannot self-approve PRs jsboige authored; identity confusion in reviews → decision
+to use distinct review tags per bot.
+
+## 3. The coordination protocol (secrétaire / rapporteur)
+
+Established and repeatedly re-asserted by Emerjesse over Telegram (2026-05-02 →
+2026-05-14). **This is the single most-corrected thing — Hermes must get it right.**
+
+- **Roles are fixed:** Hermes = secrétaire, NanoClaw = rapporteur. Hermes must
+  *never* deliver the report itself. ("TU N'ES PAS LE RAPPORTEUR", 2026-05-12.)
+- **When Emerjesse asks for something answerable by both bots:**
+  1. **ACK twice, fast** — once on Telegram, once on the dashboard. Don't think first.
+  2. Then investigate / think.
+  3. **Exchange on `workspace-cluster-coordination`** — always name the dashboard
+     explicitly, never "the dashboard".
+  4. "Protocole 20 s / 10 s": a one-shot re-pollable sleep script (~10–20 s)
+     between dashboard messages so the bots can exchange several times quickly.
+     Use a sleep *command/script*, not the scheduler (not precise enough).
+  5. Converge over a few exchanges. The **secrétaire writes the final report**,
+     the **rapporteur validates it** (or proposes edits).
+  6. **Hand-off:** the secrétaire *announces* that the rapporteur will report;
+     then the rapporteur posts the report on the Telegram group chat.
+- For long-running discussions it's OK if the protocol stalls and the answer
+  waits for the next cron. But a *requested report* must run the protocol to its
+  end — fast ACK, exchange, hand-off — even if it takes a minute or two.
+- **Anti-double-claim:** never start work until the dashboard says who does it.
+  Agreement only exists when **one bot tells the other "c'est toi qui fait"** —
+  the protocol always passes through a concession (like secrétaire→rapporteur).
+  "I'll do it" is not agreement. Read the dashboard, claim, check for collision.
+
+### Dashboard conventions
+
+- `workspace-cluster-coordination` = **the only** inter-agent convergence point.
+  All INTENT / CLAIM / DONE / bilan exchanges go here.
+- `workspace-roo-extensions` = reviews + per-agent activity logs.
+- `workspace-nanoclaw` / `workspace-hermes-agent` = each bot's *Claude Code harness*
+  inbox — talk to the harness agent (Opus) here, **not** to the other bot.
+- `global` = broadcast only; don't pollute.
+- `machine-*` = machine status.
+- **Always name the target dashboard explicitly.**
+- **Proactive condensation is FORBIDDEN.** Bots don't condense dashboards
+  themselves; only update status when obsolete. Auto-condensation handles the rest.
+- Anything wrong with a bot's tools → post it on that bot's harness dashboard so
+  the operator can relaunch it. Don't bury tool failures inside cron output.
+
+### Protocol version history
+
+V2 → v3 (`[WAKE-*]` tags reserved strictly for liveness pings) → v4.1
+(ACK Telegram → ACK dashboard → work). Source of truth issue for schedules:
+**roo-extensions#2000** (the "scheduler epic").
+
+## 4. Cron schedule (as last agreed with Emerjesse)
+
+Emerjesse's explicit spec (Telegram 2026-05-07, "epic de réglage des schedules"):
+
+- **PR review** — every 15 min effective, **alternating** between the two bots →
+  each bot runs a **30-min cron on offset slots**. Was NanoClaw `:15/:45`,
+  Hermes offset (`:05/:35` or `:15/:45` — drifted; align on offset). **24/7, no
+  time window** (Emerjesse insisted: "sans fenêtre pour les reviews"). Each run
+  also re-checks the *previous* slot's work. If no new PR this turn AND no review
+  by the other bot last turn → **terminate immediately, burn no tokens**.
+  Reviewing a PR = reading the diff at minimum. Anti-dedup: `gh api .../reviews`,
+  compare `commit_id` vs `pr.head.sha`, skip if already reviewed at same SHA,
+  re-review only on new commit.
+- **Light coordination check** — every 15 min, very light: just check for a
+  message from the other bot on `workspace-cluster-coordination`, else go back
+  to sleep. (Was once "every minute" — Emerjesse rejected that as overkill.)
+- **Cluster tour ("la tournée")** — hourly, **alternating** → 2-hour cron on
+  offset slots per bot. Full sweep: cluster workspaces, dashboards, messaging,
+  service health. This is when stalled workspaces get detected and woken via the
+  dashboard-watcher. Below an activity threshold, the tour picks an **idle task
+  at random** (maintenance / investigation / veille / consolidation / coverage)
+  using a randomization command to avoid bias.
+- **Night** — NanoClaw does *not* run the parallel tour at night (handles
+  parallelism poorly); night = long-running batched audit work tracked in a
+  follow-up issue. Hermes at night = lighter, every 2–3h tour, or a dedicated
+  long-running cron.
+- **Morning brief** — `0 8 * * *`, once/day: scan repos + coordination → 5-line
+  bilan sent on Telegram.
+
+Hermes' own cron names (from coordination archives): `hermes-pr-review`,
+`hermes-general-patrol` (hourly, posts on `workspace-cluster-coordination`),
+`hermes-cluster-tour`, `hermes-coordination-check`. The "cron coordination" was
+to be removed and `general-patrol` was the rename; deep review daily activated.
+
+## 5. Report formats Hermes posted
+
+- **`[PATROL] HH:MM`** — `Nuit/matin <state>, cluster N/6 online, X stalled,
+  0 incident nouveau, 0 INTENT/ASK en attente.` then `Active : N (...) | Stalled :
+  N (...) | IDLE : N (...) | PRs ouvertes : ~N (...)`, per-agent detail block
+  (last post on ws-roo-ext + age + state), WAKE decisions, persistent incidents,
+  backlog count, `R<N> deadline`, inbox unread. Signed `— Hermes (myia-po-2026)
+  [PATROL <slot>]`.
+- **`[INTENT]`** — announces a coordinated report; lists points to cover; asks
+  NanoClaw to post its data within 20 s; Hermes consolidates.
+- **`[CRON:review-pr] HH:MM`** — table `Repo | PR | Titre | Action`.
+- Other tags seen: `[ACK]`, `[ACK EMERJESSE]`, `[NOTE EMERJESSE]`, `[WAKE]`,
+  `[WAKE-CLAUDE] <machine>`, `[WAKE-ROO]`, `[INCIDENT]`, `[PING]`, `[TOUR+PING]`.
+- Bilan example: NanoClaw's `[RAPPORT] Bilan activité` (2026-05-14T12:56Z on
+  cluster-coordination) — Métriques table, "Ce qui marche", "Ce qui ne marche
+  pas", "Frictions récurrentes" table, "Verdict".
+
+## 6. wake-claude (bidirectional trigger)
+
+`[WAKE-CLAUDE] myia-ai-01:<workspace>` (or `[WAKE-ROO]`) posted on a dashboard is
+picked up by a PowerShell **DashboardListener** (Windows scheduled task) that
+spawns a fresh `claude -p` in the *correct* workspace. Deployed on ai-01 and
+po-2026. Regex fix shipped as roo-extensions#2162. The earlier token-burning
+Claude watcher was replaced by this script.
+
+## 7. SOUL.md / persona reconstruction hints
+
+- French-speaking coordinator bot. Operator = Emerjesse (jsboige).
+- Fixed **secrétaire** role in the secrétaire/rapporteur protocol.
+- Communication: fast first ACK, structured `[PATROL]` reports, explicit dashboard
+  names, hourly patrol cadence by day (08–19), 3-hourly at night (00, 03, 06).
+- Tone Emerjesse wants: concise, no walls of text unless justified, name things
+  explicitly, don't announce "my tools don't work" — report it on the harness
+  dashboard instead. Don't regress into hallucinated state — cross-check the
+  dashboard status against reality before asserting.
+- A short, fast first reply ("here's what I'll do") then a fuller reply after the
+  work — Emerjesse asked for this pattern explicitly (2026-05-01).
+
+## 8. PRs by both bots — last 2 weeks (2026-04-30 → 2026-05-14)
+
+**jsboige/nanoclaw:** all MERGED — #47 (PATCH#27 idle-with-pending watchdog),
+#46 (#26), #45 (#24+#25), #44 (#22+#23), #43 (#21), #42 (#20), #41 (#19),
+#40 (#18b), #39 (#18), #38 (upstream sync v2.0.30..v2.0.46 + Windows ncl pipe),
+#37 (sync), #36 (strip MCP XML), #35 (SQLITE_READONLY swallow), #34 (sync),
+#33 (list_tasks BLOB), #32 (MCP registry loss), #31 (NTFS id separator),
+#30 (MCP init failure detect), #29 (Windows named pipe), #28 (post-incident
+gap fixes), #26 (sync), #20 (bidirectional dashboard mentions), #19, #18.
+
+**jsboige/hermes-agent:** 0 PRs in window (only issues #1, #2 on 2026-05-14).
+
+## 9. Mission order — NanoClaw self-verification cron
+
+To prevent NanoClaw suffering the same fate, NanoClaw (the bot) is asked to
+**create its own scheduled task** that verifies its persistent data integrity
+in small pieces, one slice per run. See the `[TASK]` posted on `workspace-nanoclaw`.
+
+Scope, rotated one slice per run:
+1. **Session memory** — `data/v2-sessions/*/*/inbound.db` + `outbound.db`:
+   present, non-empty, readable, recent rows.
+2. **All memories** — `~/.claude/projects/d--nanoclaw/memory/*` and
+   `.claude/memory/` / `.claude/rules/`: present, MEMORY.md index in sync.
+3. **PRs by either bot, last 2 weeks** — `gh pr list` on jsboige/nanoclaw and
+   jsboige/hermes-agent: snapshot to a recovery log.
+4. **Coordination dashboard + archives** — `workspace-cluster-coordination` and
+   `workspace-nanoclaw` status + intercom + `read_archive` listing: snapshot.
+
+On any anomaly (missing file, empty DB, unreadable archive) → post `[WARN]` on
+`workspace-nanoclaw` mentioning the harness. The point is early detection, not a
+full backup — pair it with the volume-snapshot procedure of hermes-agent#2.
+
+The full NanoClaw backup & restore procedure is tracked in **jsboige/nanoclaw#48**
+([SAFETY] Backup & restore procedure for NanoClaw persistent data). Note: unlike
+Hermes, NanoClaw v2's persistence is on the host filesystem (`data/` + `groups/`),
+not a Docker volume — the failure mode differs but the snapshot-before-destructive-op
+lesson transfers.

--- a/scripts/diag-rsm-chain.mjs
+++ b/scripts/diag-rsm-chain.mjs
@@ -1,0 +1,68 @@
+// Diagnose the bot's MCP chain end-to-end through TBXark (localhost:9090 == host.docker.internal:9090).
+// Does a real streamable-http handshake (initialize -> session id -> tools/list) for each server,
+// so we distinguish "TBXark HTTP layer answers" (initialize 200) from "backend serves tools" (tools/list works).
+const BEARER = process.env.MCP_PROXY_BEARER;
+if (!BEARER) { console.error('MCP_PROXY_BEARER not set'); process.exit(2); }
+const BASE = 'http://localhost:9090';
+
+function parseBody(text) {
+  // TBXark may answer JSON or SSE (event: message\ndata: {...})
+  const t = text.trim();
+  if (t.startsWith('{')) { try { return JSON.parse(t); } catch { return null; } }
+  for (const line of t.split('\n')) {
+    const l = line.trim();
+    if (l.startsWith('data:')) { try { return JSON.parse(l.slice(5).trim()); } catch {} }
+  }
+  return null;
+}
+
+async function probe(server) {
+  const url = `${BASE}/${server}/mcp`;
+  const headers = {
+    'Authorization': `Bearer ${BEARER}`,
+    'Content-Type': 'application/json',
+    'Accept': 'application/json, text/event-stream',
+  };
+  const out = { server, init: null, sessionId: null, toolsCount: null, sampleTools: [], error: null };
+  try {
+    // 1) initialize
+    const initRes = await fetch(url, {
+      method: 'POST', headers,
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize',
+        params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'diag', version: '1' } } }),
+      signal: AbortSignal.timeout(15000),
+    });
+    out.init = initRes.status;
+    out.sessionId = initRes.headers.get('mcp-session-id') || initRes.headers.get('Mcp-Session-Id');
+    const initBody = parseBody(await initRes.text());
+    if (initRes.status !== 200) { out.error = `initialize HTTP ${initRes.status}`; return out; }
+    if (!initBody || initBody.error) { out.error = `initialize body err: ${JSON.stringify(initBody?.error)}`; return out; }
+
+    const sessHeaders = { ...headers };
+    if (out.sessionId) sessHeaders['mcp-session-id'] = out.sessionId;
+
+    // 2) initialized notification
+    await fetch(url, { method: 'POST', headers: sessHeaders,
+      body: JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }),
+      signal: AbortSignal.timeout(10000) }).catch(() => {});
+
+    // 3) tools/list — the real backend test
+    const tlRes = await fetch(url, { method: 'POST', headers: sessHeaders,
+      body: JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} }),
+      signal: AbortSignal.timeout(20000) });
+    const tlBody = parseBody(await tlRes.text());
+    if (tlRes.status !== 200) { out.error = `tools/list HTTP ${tlRes.status}`; return out; }
+    if (!tlBody || tlBody.error) { out.error = `tools/list err: ${JSON.stringify(tlBody?.error)}`; return out; }
+    const tools = tlBody.result?.tools || [];
+    out.toolsCount = tools.length;
+    out.sampleTools = tools.slice(0, 5).map((t) => t.name);
+  } catch (e) {
+    out.error = e instanceof Error ? `${e.name}: ${e.message}` : String(e);
+  }
+  return out;
+}
+
+for (const srv of ['roo-state-manager', 'sk-agent', 'searxng']) {
+  const r = await probe(srv);
+  console.log(JSON.stringify(r));
+}

--- a/scripts/drain-runaway-backlog.ts
+++ b/scripts/drain-runaway-backlog.ts
@@ -1,0 +1,167 @@
+/**
+ * One-shot drain: the ClusterManager bot accumulated a massive outbound backlog
+ * (5700+ messages, many duplicates from LLM emitting hundreds of identical
+ * <message to=...> blocks). This happened on 2026-06-07 after a Docker restart
+ * left the session in a state where the GLM model entered a production loop.
+ *
+ * Drain plan:
+ *  1. Deduplicate outbound messages: keep the first of each unique content
+ *     group, delete all duplicates. Also delete pure spam messages that have
+ *     no legitimate value (e.g. hundreds of "checking health").
+ *  2. Advance past-due recurring tasks to next cron slot.
+ *  3. Mark stale cli-resp-* system messages 'completed'.
+ *  4. Clear zombie processing_ack rows.
+ *
+ * Re-runnable, idempotent. Safe to run while service is stopped.
+ */
+import Database from 'better-sqlite3';
+import path from 'node:path';
+import { CronExpressionParser } from 'cron-parser';
+
+const SESSION_DIR = path.resolve(
+  'data/v2-sessions/ag-1776992584813-k3oj0w/sess-1776993077016-7qx60e',
+);
+const inDb = new Database(path.join(SESSION_DIR, 'inbound.db'));
+const outDb = new Database(path.join(SESSION_DIR, 'outbound.db'));
+const TZ = process.env.TZ || 'Europe/Paris';
+const now = new Date();
+const nowIso = now.toISOString();
+
+// ── Phase 0: Outbound dedup ──────────────────────────────────────────
+
+// Count before
+const totalBefore = (outDb.prepare('SELECT COUNT(*) AS c FROM messages_out').get() as { c: number }).c;
+console.log(`Outbound messages before dedup: ${totalBefore}`);
+
+// Strategy: delete all rows where there exists another row with the same content
+// but a lower seq (keep the first occurrence).
+const dedupResult = outDb.prepare(`
+  DELETE FROM messages_out
+  WHERE rowid IN (
+    SELECT b.rowid
+    FROM messages_out a
+    JOIN messages_out b ON a.content = b.content AND a.seq < b.seq
+  )
+`).run();
+console.log(`Outbound duplicates removed: ${dedupResult.changes}`);
+
+// Also: for "checking health" spam, keep at most 1 per unique text
+// (already handled by dedup above)
+
+const totalAfter = (outDb.prepare('SELECT COUNT(*) AS c FROM messages_out').get() as { c: number }).c;
+console.log(`Outbound messages after dedup: ${totalAfter}`);
+
+// ── Phase 1: Advance past-due recurring tasks ────────────────────────
+
+interface TaskRow {
+  id: string;
+  kind: string;
+  content: string;
+  recurrence: string;
+  process_after: string | null;
+  platform_id: string | null;
+  channel_type: string | null;
+  thread_id: string | null;
+  series_id: string;
+}
+
+const pastDue = inDb
+  .prepare(
+    "SELECT * FROM messages_in WHERE kind='task' AND status='pending' AND recurrence IS NOT NULL AND recurrence != '' AND process_after IS NOT NULL AND process_after < ?",
+  )
+  .all(nowIso) as TaskRow[];
+
+console.log(`Past-due recurring tasks: ${pastDue.length}`);
+
+function nextEvenSeq(db: Database.Database): number {
+  const row = db.prepare('SELECT MAX(seq) AS m FROM messages_in').get() as { m: number | null };
+  const m = row?.m ?? 0;
+  const candidate = m + 2;
+  return candidate % 2 === 0 ? candidate : candidate + 1;
+}
+
+const advance = inDb.transaction((row: TaskRow) => {
+  const interval = CronExpressionParser.parse(row.recurrence, { tz: TZ, currentDate: now });
+  const nextRun = interval.next().toISOString();
+  const newId = `task-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+  inDb
+    .prepare(
+      `INSERT INTO messages_in (id, seq, kind, timestamp, status, process_after, recurrence, platform_id, channel_type, thread_id, content, series_id)
+       VALUES (?, ?, ?, datetime('now'), 'pending', ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      newId,
+      nextEvenSeq(inDb),
+      row.kind,
+      nextRun,
+      row.recurrence,
+      row.platform_id,
+      row.channel_type,
+      row.thread_id,
+      row.content,
+      row.series_id,
+    );
+
+  inDb
+    .prepare(
+      "UPDATE messages_in SET status='completed', recurrence=NULL WHERE id = ?",
+    )
+    .run(row.id);
+
+  console.log(
+    `advanced: ${row.id} (${row.recurrence}) past_due=${row.process_after} -> new=${newId} next=${nextRun}`,
+  );
+});
+
+for (const row of pastDue) {
+  try {
+    advance(row);
+  } catch (err) {
+    console.error(`FAILED to advance ${row.id}:`, err);
+  }
+}
+
+// ── Phase 2: Mark stale cli-resp-* completed ─────────────────────────
+
+const staleCliResp = inDb
+  .prepare(
+    "UPDATE messages_in SET status='completed' WHERE kind='system' AND id LIKE 'cli-resp-%' AND status='pending'",
+  )
+  .run();
+console.log(`cli-resp drained: ${staleCliResp.changes}`);
+
+// ── Phase 3: Clear zombie processing_ack ──────────────────────────────
+
+let zombieCleared = 0;
+try {
+  const r = outDb
+    .prepare("DELETE FROM processing_ack WHERE status != 'completed'")
+    .run();
+  zombieCleared = r.changes;
+} catch (err) {
+  console.error('processing_ack cleanup error:', err);
+}
+console.log(`processing_ack zombies cleared: ${zombieCleared}`);
+
+// ── Phase 4: Snapshot post-drain state ───────────────────────────────
+
+const pending = inDb
+  .prepare(
+    "SELECT id, kind, status, recurrence, process_after FROM messages_in WHERE status='pending' ORDER BY process_after",
+  )
+  .all() as Array<Record<string, unknown>>;
+console.log('\nPending after drain:');
+for (const r of pending) console.log(r);
+
+// Sample of remaining outbound
+const sampleOut = outDb
+  .prepare('SELECT seq, timestamp, substr(content, 1, 60) AS preview FROM messages_out ORDER BY seq DESC LIMIT 10')
+  .all() as Array<Record<string, unknown>>;
+console.log('\nLast 10 outbound after dedup:');
+for (const r of sampleOut) console.log(r);
+
+inDb.close();
+outDb.close();
+
+console.log('\n✅ Drain complete.');

--- a/scripts/fix-cluster-manager-review-schedule.ts
+++ b/scripts/fix-cluster-manager-review-schedule.ts
@@ -1,0 +1,78 @@
+// One-shot fix for ClusterManager bot review-spam (12 May 2026).
+// Cleans up the schedule series `task-1778156453521-1idek6` (Review PR cron):
+//   1. Cancel obsolete pending row that still has the old `0,30 * * * *` recurrence
+//      and the pre-dedup script.
+//   2. Verify the new pending row has the new `0 8,12,16,20 * * *` recurrence + the
+//      dedup-aware script.
+// The new pending row was already created by the recurrence engine when we updated
+// the completed row earlier; this step just neutralizes the duplicate.
+import Database from 'better-sqlite3';
+import path from 'node:path';
+
+const SERIES_ID = 'task-1778156453521-1idek6';
+const DB_PATH = path.resolve(
+  'data/v2-sessions/ag-1776992584813-k3oj0w/sess-1776993077016-7qx60e/inbound.db'
+);
+
+const NEW_RECURRENCE = '0 8,12,16,20 * * *';
+
+const db = new Database(DB_PATH);
+
+console.log('=== BEFORE ===');
+const before = db
+  .prepare(
+    `SELECT id, status, recurrence, process_after
+     FROM messages_in
+     WHERE series_id = ? AND status = 'pending'
+     ORDER BY process_after ASC`
+  )
+  .all(SERIES_ID) as Array<{
+  id: string;
+  status: string;
+  recurrence: string | null;
+  process_after: string | null;
+}>;
+for (const r of before) {
+  console.log(`  ${r.id}  ${r.status}  recurrence=${r.recurrence}  process_after=${r.process_after}`);
+}
+
+// Cancel any pending row in this series whose recurrence is NOT the new one.
+const cancel = db
+  .prepare(
+    `UPDATE messages_in
+     SET status = 'completed', recurrence = NULL
+     WHERE series_id = ?
+       AND kind = 'task'
+       AND status = 'pending'
+       AND recurrence IS NOT ?`
+  )
+  .run(SERIES_ID, NEW_RECURRENCE);
+console.log(`\nObsolete pending rows cancelled: ${cancel.changes}`);
+
+console.log('\n=== AFTER ===');
+const after = db
+  .prepare(
+    `SELECT id, status, recurrence, process_after
+     FROM messages_in
+     WHERE series_id = ? AND status = 'pending'
+     ORDER BY process_after ASC`
+  )
+  .all(SERIES_ID) as Array<{
+  id: string;
+  status: string;
+  recurrence: string | null;
+  process_after: string | null;
+}>;
+for (const r of after) {
+  console.log(`  ${r.id}  ${r.status}  recurrence=${r.recurrence}  process_after=${r.process_after}`);
+}
+
+if (after.length === 1 && after[0].recurrence === NEW_RECURRENCE) {
+  console.log('\nOK: exactly one pending row, with new recurrence.');
+  process.exit(0);
+} else {
+  console.error('\nWARNING: state is not the expected single-pending-row.');
+  process.exit(1);
+}
+
+db.close();

--- a/scripts/force-review-now.ts
+++ b/scripts/force-review-now.ts
@@ -1,0 +1,29 @@
+// One-shot: advance the pending Review PR task to fire now.
+// Companion to the audit-script JSON fix (2026-05-26).
+import Database from 'better-sqlite3';
+import path from 'node:path';
+
+const DB_PATH = path.resolve(
+  'data/v2-sessions/ag-1776992584813-k3oj0w/sess-1776993077016-7qx60e/inbound.db'
+);
+const TASK_ID = 'task-1779818855501-rgv0v1';
+
+const db = new Database(DB_PATH);
+
+const before = db
+  .prepare('SELECT id, status, process_after, recurrence FROM messages_in WHERE id = ?')
+  .get(TASK_ID);
+console.log('BEFORE:', before);
+
+const now = new Date().toISOString();
+const res = db
+  .prepare("UPDATE messages_in SET process_after = ? WHERE id = ? AND status = 'pending'")
+  .run(now, TASK_ID);
+console.log(`rows updated: ${res.changes}`);
+
+const after = db
+  .prepare('SELECT id, status, process_after, recurrence FROM messages_in WHERE id = ?')
+  .get(TASK_ID);
+console.log('AFTER:', after);
+
+db.close();

--- a/scripts/patch-tls-workaround.ts
+++ b/scripts/patch-tls-workaround.ts
@@ -1,0 +1,49 @@
+/**
+ * One-shot patch: add NODE_TLS_REJECT_UNAUTHORIZED=0 + required:false to the
+ * ClusterManager bot's MCP server config so it can boot while the
+ * mcp-tools.myia.io TLS cert is broken (SAN missing for that hostname,
+ * renewed 2026-05-09, only covers DNS:myia.io).
+ *
+ * Revert: remove `required: false` and the env var, restart bot.
+ */
+import Database from 'better-sqlite3';
+import path from 'node:path';
+
+const AG_ID = 'ag-1776992584813-k3oj0w';
+const dbPath = path.resolve('data/v2.db');
+const db = new Database(dbPath);
+
+const row = db
+  .prepare('SELECT mcp_servers FROM container_configs WHERE agent_group_id = ?')
+  .get(AG_ID) as { mcp_servers: string } | undefined;
+if (!row) throw new Error(`No container_configs row for ${AG_ID}`);
+
+const cfg = JSON.parse(row.mcp_servers) as Record<
+  string,
+  {
+    command: string;
+    args: string[];
+    env?: Record<string, string>;
+    timeout?: number;
+    required?: boolean;
+  }
+>;
+
+for (const name of Object.keys(cfg)) {
+  cfg[name].env = { ...(cfg[name].env ?? {}), NODE_TLS_REJECT_UNAUTHORIZED: '0' };
+  cfg[name].required = false;
+  console.log(`patched ${name}: required=false, NODE_TLS_REJECT_UNAUTHORIZED=0`);
+}
+
+const newJson = JSON.stringify(cfg);
+db.prepare('UPDATE container_configs SET mcp_servers = ?, updated_at = ? WHERE agent_group_id = ?').run(
+  newJson,
+  new Date().toISOString(),
+  AG_ID,
+);
+
+const after = db
+  .prepare('SELECT mcp_servers FROM container_configs WHERE agent_group_id = ?')
+  .get(AG_ID) as { mcp_servers: string };
+console.log('AFTER:', after.mcp_servers);
+db.close();

--- a/scripts/revert-tls-workaround.ts
+++ b/scripts/revert-tls-workaround.ts
@@ -1,0 +1,52 @@
+/**
+ * One-shot revert: drop NODE_TLS_REJECT_UNAUTHORIZED=0 + required:false from
+ * the ClusterManager bot's MCP server config now that the
+ * mcp-tools.myia.io cert has been reissued (2026-05-18) with proper SAN
+ * coverage (verified 2026-05-28 19:38Z via openssl + strict curl).
+ *
+ * Restores the proactive `mcp-health` probe safety net.
+ */
+import Database from 'better-sqlite3';
+import path from 'node:path';
+
+const AG_ID = 'ag-1776992584813-k3oj0w';
+const dbPath = path.resolve('data/v2.db');
+const db = new Database(dbPath);
+
+const row = db
+  .prepare('SELECT mcp_servers FROM container_configs WHERE agent_group_id = ?')
+  .get(AG_ID) as { mcp_servers: string } | undefined;
+if (!row) throw new Error(`No container_configs row for ${AG_ID}`);
+
+const cfg = JSON.parse(row.mcp_servers) as Record<
+  string,
+  {
+    command: string;
+    args: string[];
+    env?: Record<string, string>;
+    timeout?: number;
+    required?: boolean;
+  }
+>;
+
+for (const name of Object.keys(cfg)) {
+  if (cfg[name].env) {
+    delete cfg[name].env!.NODE_TLS_REJECT_UNAUTHORIZED;
+    if (Object.keys(cfg[name].env!).length === 0) delete cfg[name].env;
+  }
+  delete cfg[name].required;
+  console.log(`reverted ${name}: removed required + NODE_TLS_REJECT_UNAUTHORIZED`);
+}
+
+const newJson = JSON.stringify(cfg);
+db.prepare('UPDATE container_configs SET mcp_servers = ?, updated_at = ? WHERE agent_group_id = ?').run(
+  newJson,
+  new Date().toISOString(),
+  AG_ID,
+);
+
+const after = db
+  .prepare('SELECT mcp_servers FROM container_configs WHERE agent_group_id = ?')
+  .get(AG_ID) as { mcp_servers: string };
+console.log('AFTER:', after.mcp_servers);
+db.close();


### PR DESCRIPTION
## What
Commits 7 fork-local operational/recovery scripts that had accumulated **untracked** in the working tree across operating sessions of the ClusterManager bot. Pure additions — no changes to any existing tracked file.

| File | Purpose |
|------|---------|
| `scripts/diag-rsm-chain.mjs` | End-to-end MCP-chain probe through TBXark (`initialize → session id → tools/list` per server). Companion to the committed `bypass-mcp-edge.ts`. Bearer from `MCP_PROXY_BEARER` env. |
| `scripts/drain-runaway-backlog.ts` | Idempotent drain for the runaway-outbound-backlog incident (dedup outbound, advance past-due recurring tasks, clear zombie acks). |
| `scripts/fix-cluster-manager-review-schedule.ts` | One-shot: neutralize a duplicate pending row in a review-schedule series. |
| `scripts/force-review-now.ts` | One-shot: advance a pending Review-PR task to fire now. |
| `scripts/patch-tls-workaround.ts` / `scripts/revert-tls-workaround.ts` | Reversible pair toggling `NODE_TLS_REJECT_UNAUTHORIZED=0` + `required:false` for the `mcp-tools.myia.io` cert SAN gap. |
| `hermes-recovery-2026-05-14.md` | Recovery artifact for the Hermes 2026-05-14 memory-loss incident; referenced by this machine's MEMORY.md. |

## Why
Keep the working tree clean and version the operational tooling so it isn't lost. These are consistent with the fork's existing `scripts/` cluster tooling (`bypass-mcp-edge.ts`, `seed-jsboige-*`, `watchdog-tbxark.ps1`).

## Scope / safety
- **Fork-internal only.** Targets `origin/main` (jsboige/nanoclaw), not upstream `qwibitai/nanoclaw`. Not an upstream-mergeable feature — these are cluster-specific ops tools.
- **No secrets.** Bearer read from env; the hardcoded `ag-…` / `sess-…` / `task-…` strings are internal identifiers, not credentials.
- **No PATCHES.md entry needed** — pure new files, zero upstream conflict surface (PATCHES.md tracks `src/`+`container/` modifications only).

## Tested
Each script was authored and run against the live install during the incidents it addresses. This PR only version-controls them; no behavior change to the host or container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)