### PR TITLE
fix(agent-runner): suppress provider auto-compaction telemetry from user channels [PATCH-myia #40]

### DIFF
--- a/PATCHES.md
+++ b/PATCHES.md
@@ -396,6 +396,14 @@ If none works, document the patch here with justification.
 - **Exit condition:** Upstream sets a sane `NO_PROXY` when it injects the OneCLI proxy env (so internal `host.docker.internal` MCP/loopback traffic bypasses the credential proxy by default), or OneCLI's `applyContainerConfig` grows a no-proxy allowlist parameter.
 - **Lines:** ~6 (+ comment block)
 
+### 40. Suppress provider auto-compaction telemetry from user channels
+
+- **File:** `container/agent-runner/src/poll-loop.ts` — new `isProviderStatusNoise()` helper + guards at the three fallback delivery sites: `deliverErrorResult()`, the `#19` bare-text routing-source fallback in `dispatchResultText()`, and the reactive catch-path `Error: ${errMsg}` write.
+- **Summary:** A single guard drops known SDK/CLI status telemetry — `Context compacted (N tokens compacted).`, `Autocompact is thrashing…`, `Claude Code returned an error result: …` (with an optional leading `Error: ` stripped) — instead of writing it to the channel. Each site logs the suppressed text and skips the `writeMessageOut`. The `#19` site returns early so no re-wrap nudge fires for pure telemetry.
+- **Why:** When a heavy turn (esp. the review cron) balloons context, Claude Code auto-compacts repeatedly and emits these notices as result text or as an error result/throw with no `<message>` envelope. All three fallback paths — which exist to surface *real* unwrapped replies — then post the raw telemetry to the group. Incident 2026-07-15: **91 of 93** chat deliveries to the Telegram group over ~11h were this noise (`Context compacted…`/`Autocompact is thrashing…`), drowning real replies. Distinct from the underlying poids-par-tour thrash (#2177, unfixed) — this patch stops the *leak*; the review work itself still lands on GitHub/dashboard. Genuine agent text and genuine provider errors (403 billing_error, MCP init failures) do not match and are unaffected.
+- **Exit condition:** Upstream stops routing provider status/telemetry strings through the user-facing fallback delivery paths (e.g. tags result events as internal telemetry vs. agent output), or exposes a hook to filter fallback deliveries.
+- **Lines:** ~30 (helper + 3 guards + comments)
+
 ---
 
 ## Removed / not needed under v2

--- a/container/agent-runner/src/poll-loop.test.ts
+++ b/container/agent-runner/src/poll-loop.test.ts
@@ -4,8 +4,15 @@ import { initTestSessionDb, closeSessionDb, getInboundDb, getOutboundDb } from '
 import { getPendingMessages, markCompleted } from './db/messages-in.js';
 import { getUndeliveredMessages } from './db/messages-out.js';
 import { formatMessages, extractRouting } from './formatter.js';
-// [PATCH-myia #28] evaluateToolStuckBudget, [PATCH-myia #35] evaluateStaleRetryCap
-import { evaluateStaleRetryCap, evaluateToolStuckBudget, isCorruptionError, processQuery } from './poll-loop.js';
+// [PATCH-myia #28] evaluateToolStuckBudget, [PATCH-myia #35] evaluateStaleRetryCap,
+// [PATCH-myia #40] isProviderStatusNoise
+import {
+  evaluateStaleRetryCap,
+  evaluateToolStuckBudget,
+  isCorruptionError,
+  isProviderStatusNoise,
+  processQuery,
+} from './poll-loop.js';
 import { MockProvider } from './providers/mock.js';
 import type { AgentQuery, ProviderEvent } from './providers/types.js';
 
@@ -710,5 +717,96 @@ describe('isCorruptionError', () => {
     expect(isCorruptionError('database is locked')).toBe(false);
     expect(isCorruptionError('no such table: messages_in')).toBe(false);
     expect(isCorruptionError('')).toBe(false);
+  });
+});
+
+// [PATCH-myia #40] Provider status telemetry must never reach a user channel.
+// Incident 2026-07-15: 91 of 93 chat deliveries to the Telegram group over ~11h
+// were auto-compaction notices ("Context compacted (N tokens compacted)." /
+// "Autocompact is thrashing…") that a heavy turn emitted with no <message>
+// envelope, leaking through poll-loop's three fallback delivery paths. The
+// narrow predicate below drops exactly those families while leaving genuine
+// agent text and genuine provider errors untouched. See PATCHES.md#40.
+describe('[PATCH-myia #40] isProviderStatusNoise', () => {
+  it('matches the "Context compacted (N tokens compacted)." notice', () => {
+    expect(isProviderStatusNoise('Context compacted (169,252 tokens compacted).')).toBe(true);
+  });
+
+  it('matches "Autocompact is thrashing…"', () => {
+    expect(
+      isProviderStatusNoise('Autocompact is thrashing: context refilled to the limit within 3 turns'),
+    ).toBe(true);
+  });
+
+  it('matches "Claude Code returned an error result: …"', () => {
+    expect(isProviderStatusNoise('Claude Code returned an error result: Autocompact is thrashing')).toBe(true);
+  });
+
+  it('strips a leading "Error: " prefix before matching (catch-path shape)', () => {
+    // The reactive catch path wraps the throw as `Error: ${errMsg}` before the
+    // channel write — the guard must see through that prefix.
+    expect(isProviderStatusNoise('Error: Autocompact is thrashing')).toBe(true);
+    expect(isProviderStatusNoise('Error: Claude Code returned an error result: x')).toBe(true);
+  });
+
+  it('tolerates surrounding whitespace', () => {
+    expect(isProviderStatusNoise('  Context compacted (5 tokens compacted).\n')).toBe(true);
+  });
+
+  it('does NOT match genuine agent text', () => {
+    expect(isProviderStatusNoise('The answer is 4')).toBe(false);
+    expect(isProviderStatusNoise('bare text, no envelope')).toBe(false);
+    // A message that merely mentions compaction mid-sentence is not a notice.
+    expect(isProviderStatusNoise('I compacted the context, here is the summary')).toBe(false);
+  });
+
+  it('does NOT match genuine provider errors (403 billing, MCP init)', () => {
+    expect(
+      isProviderStatusNoise('Spending limit reached. Add your own key at https://example.com/keys'),
+    ).toBe(false);
+    expect(isProviderStatusNoise('Error: MCP servers not connected at init')).toBe(false);
+    expect(isProviderStatusNoise('')).toBe(false);
+  });
+});
+
+describe('[PATCH-myia #40] provider status noise is not delivered to channels', () => {
+  it('suppresses a "Context compacted" non-error result with no <message> envelope (Site A)', async () => {
+    const { query, pushes } = makeResultQuery({
+      type: 'result',
+      text: 'Context compacted (169,252 tokens compacted).',
+    });
+
+    await processQuery(query, ERR_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+
+    // Without the guard this would fall through the #19 routing-source fallback
+    // and post to the channel. Nothing delivered, and no re-wrap nudge fired.
+    expect(getUndeliveredMessages()).toHaveLength(0);
+    expect(pushes).toHaveLength(0);
+  });
+
+  it('suppresses an "Autocompact is thrashing" error result with no envelope (Site B)', async () => {
+    const { query, pushes } = makeResultQuery({
+      type: 'result',
+      text: 'Autocompact is thrashing: context refilled to the limit within 3 turns',
+      isError: true,
+    });
+
+    await processQuery(query, ERR_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+
+    // Error turns with no envelope route through deliverErrorResult, which now
+    // drops known telemetry. No delivery, no nudge.
+    expect(getUndeliveredMessages()).toHaveLength(0);
+    expect(pushes).toHaveLength(0);
+  });
+
+  it('still delivers a genuine billing error (regression guard — filter is narrow)', async () => {
+    const budgetText = 'Spending limit reached. Add your own key at https://example.com/keys';
+    const { query } = makeResultQuery({ type: 'result', text: budgetText, isError: true });
+
+    await processQuery(query, ERR_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+
+    const out = getUndeliveredMessages();
+    expect(out).toHaveLength(1);
+    expect(JSON.parse(out[0].content).text).toBe(budgetText);
   });
 });

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -718,6 +718,12 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
           stalledAborted = true;
           await sleep(BLOCKED_RETRY_BACKOFF_MS);
         }
+      } else if (isProviderStatusNoise(errMsg)) {
+        // [PATCH-myia #40] Don't leak auto-compaction telemetry ("Autocompact
+        // is thrashing…" / "Claude Code returned an error result: …") to the
+        // channel — log only. Genuine errors still fall through to the write
+        // below (incident 2026-07-15).
+        log(`Suppressed provider status noise from query-error channel write: ${errMsg.slice(0, 80)}`);
       } else {
         writeMessageOut({
           id: generateId(),
@@ -1466,6 +1472,29 @@ function handleEvent(event: ProviderEvent, _routing: RoutingContext): void {
 }
 
 /**
+ * [PATCH-myia #40] SDK/CLI status telemetry that must never reach a user
+ * channel. When a heavy turn auto-compacts, the provider emits notices like
+ * `Context compacted (N tokens compacted).` as result text, or returns/throws
+ * `Autocompact is thrashing…` / `Claude Code returned an error result: …`.
+ * All three of poll-loop's fallback delivery paths (deliverErrorResult, the
+ * #19 bare-text routing-source fallback, and the reactive catch-path `Error:`
+ * write) would otherwise post these to the group. Incident 2026-07-15: 91 of
+ * 93 chat deliveries to the Telegram group over ~11h were this noise, drowning
+ * real replies. These are internal telemetry — log them, never deliver. A
+ * leading `Error: ` prefix (added by the catch path) is stripped before match.
+ * Genuine agent text and genuine provider errors (403 billing_error, MCP init
+ * failures, etc.) do NOT match and are delivered as before.
+ */
+export function isProviderStatusNoise(text: string): boolean {
+  const t = text.trim().replace(/^Error:\s*/, '');
+  return (
+    /^Context compacted \(/.test(t) ||
+    /^Autocompact is thrashing\b/.test(t) ||
+    /^Claude Code returned an error result\b/.test(t)
+  );
+}
+
+/**
  * Deliver a turn's text straight to the channel the batch arrived on. Used when
  * a turn ends in a provider error (e.g. a non-retryable 403 billing_error) with
  * no <message> envelope: the notice would otherwise be dropped as scratchpad.
@@ -1473,6 +1502,11 @@ function handleEvent(event: ProviderEvent, _routing: RoutingContext): void {
  * `Error:` prefix — the provider's text is already a user-facing message.
  */
 function deliverErrorResult(text: string, routing: RoutingContext): void {
+  if (isProviderStatusNoise(text)) {
+    // [PATCH-myia #40] Log, don't deliver — auto-compaction telemetry.
+    log(`Suppressed provider status noise from error-result channel delivery: ${text.trim().slice(0, 80)}`);
+    return;
+  }
   log('Error result with no <message> envelope — delivering to channel');
   writeMessageOut({
     id: generateId(),
@@ -1567,6 +1601,19 @@ function dispatchResultText(
   // recurs especially after MCP registry loss → continuation cleared → fresh
   // SDK init that sometimes drops the destination-wrapping discipline.
   //
+  // [PATCH-myia #40] Drop provider status telemetry before any fallback
+  // delivery. A heavy turn that only auto-compacted emits e.g. "Context
+  // compacted (N tokens compacted)." as its sole text with no <message>
+  // envelope; without this it reaches the user's channel via the #19 fallback
+  // below (incident 2026-07-15: 91/93 group deliveries were this noise). Return
+  // early so no channel write AND no re-wrap nudge fires for pure telemetry.
+  if (!isError && sent === 0 && isProviderStatusNoise(scratchpad)) {
+    log(
+      `Suppressed provider status noise from routing-source fallback (${scratchpad.trim().length} chars): ${scratchpad.trim().slice(0, 80)}`,
+    );
+    return { sent: 0, hasUnwrapped: false };
+  }
+
   // We only fall back when:
   //   - !isError (error turns flow through the caller's deliverErrorResult
   //     path instead — single delivery, status 'error' archived; without this


### PR DESCRIPTION
## Problem

**Incident 2026-07-15**: **91 of 93** chat deliveries to the ClusterManager Telegram group over ~11h were provider auto-compaction notices — `Context compacted (N tokens compacted).` and `Autocompact is thrashing…` — drowning the two real replies.

A heavy proactive tour (esp. the review cron) balloons context → Claude Code auto-compacts repeatedly → emits these notices as **result text** or as an **error result / throw** with no `<message>` envelope. All three of poll-loop's fallback delivery paths — which exist to surface *genuine* unwrapped replies so the user still gets something — then post the raw telemetry to the channel.

This is distinct from the underlying poids-par-tour auto-compact thrash (upstream #2177, unfixed). **This PR stops the *leak*; the review work itself still lands on GitHub/dashboard via MCP.** c2 / PR #58 (STALL_TIMEOUT_MS 240s) stopped the turns from *wedging* but not the noise emission.

## Fix

A narrow `isProviderStatusNoise()` predicate + a guard at each of the three fallback sites in `container/agent-runner/src/poll-loop.ts`:

| Site | Path | Noise family |
|------|------|--------------|
| A | `dispatchResultText` #19 bare-text routing-source fallback | `Context compacted (…` |
| B | `deliverErrorResult` | `Autocompact is thrashing…` |
| C | reactive catch-path `Error: ${errMsg}` write | `Claude Code returned an error result: …` (opt. `Error: ` prefix) |

Matched text is **logged and dropped**, never delivered. Site A returns early so no re-wrap nudge fires for pure telemetry. A leading `Error: ` prefix (added by the catch path) is stripped before matching.

The predicate is deliberately anchored (`^`) and narrow: **genuine agent text** and **genuine provider errors** (403 `billing_error`, `MCP servers not connected at init`) do **not** match and are delivered exactly as before.

## Tests

- 3 new cases: predicate families (incl. `Error:`-prefix + whitespace + negative genuine-text/error), Site A suppression, Site B suppression, and a **billing-error passthrough regression guard**.
- `bun test`: **185 pass, 0 fail**. `tsc --noEmit`: clean.

## Overlay

New fork overlay patch **#40** in `PATCHES.md` with exit condition (upstream stops routing telemetry through user-facing fallback paths, or exposes a filter hook).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)