### PR TITLE
fix(agent-runner): re-check continuation-rotation guard mid-life to prevent accumulation wedge [PATCH-myia #41]

### DIFF
--- a/PATCHES.md
+++ b/PATCHES.md
@@ -398,6 +398,17 @@ If none works, document the patch here with justification.
 
 ---
 
+### 41. Re-check the continuation-rotation guard mid-life (idle), not just at startup
+
+- **File:** `container/agent-runner/src/poll-loop.ts` — new exported pure helper `evaluateMidLifeRotation`, a `ROTATE_CHECK_INTERVAL_MS` constant, a `lastRotateCheckAt` bookkeeping var in `runPollLoop`, and a call in the idle branch (`messages.length === 0`). Tests in `poll-loop.test.ts`.
+- **Summary:** The provider's `maybeRotateContinuation` guard (Claude: rotate the session when its transcript `.jsonl` exceeds `CLAUDE_TRANSCRIPT_ROTATE_BYTES`, default 12 MB, or the age cap) is evaluated **once**, just before the poll loop. This patch re-evaluates it while idle — throttled to once per `ROTATE_CHECK_INTERVAL_MS` (60 s) — so a session whose transcript crosses the cap *between* tours is rotated to a fresh transcript before the next tour resumes it. On a hit it drops the continuation (the same reset the manual zombie recovery performs), pre-emptively. Idle is chosen because the probe renames the live `.jsonl` aside, which is only safe when no query holds it.
+- **Why:** The `#2177` "zombie-heartbeat" wedges have two classes. The *bunching* class (two proactive tours claimed in one turn) is addressed by patch #26's 240 s watchdog + host de-bunching. The *accumulation* class is not: a container that stays up for hours (heartbeat keep-alive #30 keeps it alive precisely so it isn't reaped hourly) keeps resuming and appending to one transcript. The SDK only sometimes forks a fresh session on compaction; when it doesn't, the `.jsonl` grows unbounded. Wedge #7 (2026-07-16) reached **21 MB** — well past the 12 MB cap that would have rotated it at startup — but the guard never re-ran mid-life, so the SDK query died mid-thrash and the file-touch heartbeat kept ticking, so the heartbeat reap never fired → silent multi-hour wedge, manual recovery required. This patch closes that gap by making the existing, already-tested guard fire during the container's life, capping transcript growth below the wedge zone automatically.
+- **Scope caveat:** Prevents the *accumulation* wedge (transcript → 21 MB), not the *single-catastrophic-tour* wedge (a turn that crosses the cap and dies before returning to idle) — patch #26's watchdog covers that timing. Does not reduce per-tour compaction thrash itself (the deeper `poids-par-tour` lever); it bounds the cumulative bloat that thrash produces.
+- **Exit condition:** Upstream makes the SDK reliably fork a fresh session on compaction (so no single transcript grows unbounded), or `maybeRotateContinuation` is moved into the loop upstream.
+- **Lines:** ~20 (helper + idle-branch call + constant/var + comments)
+
+---
+
 ## Removed / not needed under v2
 
 ### ~~Mount allowlist env override~~ — SUPERSEDED BY V2 NATIVE (2026-04-24)

--- a/container/agent-runner/src/poll-loop.test.ts
+++ b/container/agent-runner/src/poll-loop.test.ts
@@ -4,8 +4,15 @@ import { initTestSessionDb, closeSessionDb, getInboundDb, getOutboundDb } from '
 import { getPendingMessages, markCompleted } from './db/messages-in.js';
 import { getUndeliveredMessages } from './db/messages-out.js';
 import { formatMessages, extractRouting } from './formatter.js';
-// [PATCH-myia #28] evaluateToolStuckBudget, [PATCH-myia #35] evaluateStaleRetryCap
-import { evaluateStaleRetryCap, evaluateToolStuckBudget, isCorruptionError, processQuery } from './poll-loop.js';
+// [PATCH-myia #28] evaluateToolStuckBudget, [PATCH-myia #35] evaluateStaleRetryCap,
+// [PATCH-myia #41] evaluateMidLifeRotation
+import {
+  evaluateMidLifeRotation,
+  evaluateStaleRetryCap,
+  evaluateToolStuckBudget,
+  isCorruptionError,
+  processQuery,
+} from './poll-loop.js';
 import { MockProvider } from './providers/mock.js';
 import type { AgentQuery, ProviderEvent } from './providers/types.js';
 
@@ -710,5 +717,82 @@ describe('isCorruptionError', () => {
     expect(isCorruptionError('database is locked')).toBe(false);
     expect(isCorruptionError('no such table: messages_in')).toBe(false);
     expect(isCorruptionError('')).toBe(false);
+  });
+});
+
+// [PATCH-myia #41] Mid-life continuation rotation. maybeRotateContinuation
+// (the transcript-size/age cold-resume guard) is evaluated only at container
+// startup; a container up for hours never re-checks, so a transcript that
+// grows past the cap between tours rides into the #2177 cold-resume/thrash
+// wedge (wedge #7 reached 21MB). The idle branch calls evaluateMidLifeRotation
+// to re-probe, throttled. Test the pure policy (probe injected) rather than
+// driving runPollLoop's infinite loop — same approach as #28's watchdog.
+describe('[PATCH-myia #41] evaluateMidLifeRotation', () => {
+  const INTERVAL = 60_000;
+  const base = { nowMs: 1_000_000, lastCheckMs: 0, intervalMs: INTERVAL };
+
+  it('does not check when there is no continuation to rotate', () => {
+    const probe = () => 'transcript 21.0MB > 12MB cap';
+    const r = evaluateMidLifeRotation({ ...base, continuation: undefined, probe });
+    expect(r).toEqual({ checked: false, reason: null });
+  });
+
+  it('does not check when the provider has no rotation guard', () => {
+    const r = evaluateMidLifeRotation({ ...base, continuation: 'sess-a', probe: undefined });
+    expect(r).toEqual({ checked: false, reason: null });
+  });
+
+  it('is throttled — no probe before the interval elapses', () => {
+    let calls = 0;
+    const probe = () => {
+      calls++;
+      return null;
+    };
+    const r = evaluateMidLifeRotation({
+      continuation: 'sess-a',
+      nowMs: 30_000,
+      lastCheckMs: 0,
+      intervalMs: INTERVAL,
+      probe,
+    });
+    expect(r.checked).toBe(false);
+    expect(calls).toBe(0);
+  });
+
+  it('checks exactly at the interval boundary', () => {
+    const probe = () => null;
+    const r = evaluateMidLifeRotation({
+      continuation: 'sess-a',
+      nowMs: INTERVAL,
+      lastCheckMs: 0,
+      intervalMs: INTERVAL,
+      probe,
+    });
+    expect(r.checked).toBe(true);
+    expect(r.reason).toBeNull();
+  });
+
+  it('checks but does not rotate when the transcript is under the cap', () => {
+    const r = evaluateMidLifeRotation({ ...base, continuation: 'sess-a', probe: () => null });
+    expect(r).toEqual({ checked: true, reason: null });
+  });
+
+  it('surfaces the rotate reason when the transcript is over the cap (the wedge case)', () => {
+    const reason = 'transcript 21.0MB > 12MB cap';
+    const r = evaluateMidLifeRotation({ ...base, continuation: 'sess-a', probe: () => reason });
+    expect(r).toEqual({ checked: true, reason });
+  });
+
+  it('passes the live continuation id to the probe', () => {
+    let seen: string | undefined;
+    evaluateMidLifeRotation({
+      ...base,
+      continuation: 'sess-live-123',
+      probe: (c) => {
+        seen = c;
+        return null;
+      },
+    });
+    expect(seen).toBe('sess-live-123');
   });
 });

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -151,6 +151,17 @@ const TOOL_STUCK_CHECK_INTERVAL_MS = 30_000;
 // resources the same afternoon.
 const IDLE_KEEPALIVE_MS = 2 * 60 * 60 * 1000;
 
+// [PATCH-myia #41] How often, while idle, to re-evaluate the provider's
+// continuation-rotation guard (transcript size/age cold-resume cap). The guard
+// is otherwise only checked once at container startup; a container that stays
+// up for hours never re-checks, so a transcript that grows past the cap
+// *between* tours rides an ever-growing .jsonl into the cold-resume/thrash
+// wedge (#2177 zombie — wedge #7 reached 21MB before the SDK query died).
+// 60s is far finer than the multi-hour growth that produced the wedge, and the
+// probe (findTranscriptPath + statSync) is cheap, so this adds no meaningful
+// idle cost while closing the mid-life gap.
+const ROTATE_CHECK_INTERVAL_MS = 60_000;
+
 // [PATCH-myia #29] Fail-fast gate softening. The per-turn required-MCP gate
 // (further down) previously, on a probe failure, wrote a 🛑 BLOCKED chat
 // message AND `markCompleted`'d the user's message — permanently dropping it.
@@ -272,6 +283,37 @@ export function isCorruptionError(msg: string): boolean {
   );
 }
 
+/**
+ * [PATCH-myia #41] Mid-life continuation-rotation policy.
+ *
+ * The provider's `maybeRotateContinuation` guard (transcript size/age
+ * cold-resume cap) is evaluated once at startup — see the call just before the
+ * poll loop. A long-lived container never re-checks it, so a transcript that
+ * grows past the cap between tours rides an ever-growing .jsonl into the
+ * cold-resume/thrash wedge (#2177 zombie; wedge #7 reached 21MB before the SDK
+ * query died). The idle branch calls this to decide whether to re-probe now.
+ *
+ * Pure — the probe is injected — so the throttle policy is unit-testable
+ * without driving the loop or touching the filesystem. `checked` reports
+ * whether the probe ran (caller advances its throttle clock on true); `reason`
+ * is the non-null rotate reason when a rotation should fire.
+ *
+ * Only re-checks while genuinely idle: the probe renames the live .jsonl aside
+ * as a side effect, which is only safe when no query holds it.
+ */
+export function evaluateMidLifeRotation(args: {
+  continuation: string | undefined;
+  nowMs: number;
+  lastCheckMs: number;
+  intervalMs: number;
+  probe: ((continuation: string) => string | null) | undefined;
+}): { checked: boolean; reason: string | null } {
+  const { continuation, nowMs, lastCheckMs, intervalMs, probe } = args;
+  if (!continuation || !probe) return { checked: false, reason: null };
+  if (nowMs - lastCheckMs < intervalMs) return { checked: false, reason: null };
+  return { checked: true, reason: probe(continuation) };
+}
+
 function log(msg: string): void {
   console.error(`[poll-loop] ${msg}`);
 }
@@ -359,6 +401,10 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
   // [PATCH-myia #30] Idle keep-alive bookkeeping. Timestamp of when the
   // current uninterrupted idle stretch began (0 = not currently idle).
   let idleSince = 0;
+  // [PATCH-myia #41] Last time the idle branch re-evaluated the continuation
+  // rotation guard (0 = never this container). Throttled by
+  // ROTATE_CHECK_INTERVAL_MS.
+  let lastRotateCheckAt = 0;
   // [PATCH-myia #29] When we last posted a 🛑 BLOCKED notice (0 = never).
   // Throttles the user-visible message while the MCP chain is flapping.
   let lastBlockedNoticeAt = 0;
@@ -391,6 +437,31 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
       const nowIdle = Date.now();
       if (idleSince === 0) idleSince = nowIdle;
       if (nowIdle - idleSince < IDLE_KEEPALIVE_MS) touchHeartbeat();
+
+      // [PATCH-myia #41] Mid-life continuation rotation. Re-evaluate the
+      // provider's transcript-size/age guard here — idle is the only point
+      // with no active query holding the .jsonl, so the probe's rename-aside
+      // is safe. Without this, the guard runs only at startup and a container
+      // up for hours grows its transcript past the cap into a cold-resume/
+      // thrash wedge (#2177; wedge #7 hit 21MB). On a hit, drop the
+      // continuation so the next turn starts a fresh transcript — the same
+      // reset the manual zombie recovery performs, done pre-emptively.
+      const rot = evaluateMidLifeRotation({
+        continuation,
+        nowMs: nowIdle,
+        lastCheckMs: lastRotateCheckAt,
+        intervalMs: ROTATE_CHECK_INTERVAL_MS,
+        probe: config.provider.maybeRotateContinuation
+          ? (c) => config.provider.maybeRotateContinuation!(c, config.cwd)
+          : undefined,
+      });
+      if (rot.checked) lastRotateCheckAt = nowIdle;
+      if (rot.reason) {
+        log(`Rotating session mid-life — ${rot.reason}; next turn starts fresh`);
+        clearContinuation(config.providerName);
+        continuation = undefined;
+      }
+
       await sleep(POLL_INTERVAL_MS);
       continue;
     }


### PR DESCRIPTION
## Problem — the accumulation wedge (today's incident, wedge #7)

`maybeRotateContinuation` (the provider's transcript size/age cold-resume guard — Claude rotates the session when its `.jsonl` exceeds `CLAUDE_TRANSCRIPT_ROTATE_BYTES`, default **12 MB**) is evaluated **once**, at container startup (`runPollLoop`, just before the poll loop).

A container that stays up for hours (the idle keep-alive, patch #30, deliberately keeps it alive so it isn't reaped hourly) keeps resuming and appending to one transcript. The SDK only *sometimes* forks a fresh session on compaction; when it doesn't, the `.jsonl` grows unbounded and the startup-only guard never re-runs.

**Wedge #7 (2026-07-16):** the transcript reached **21 MB** — well past the 12 MB cap that would have rotated it at startup — the SDK query died mid-thrash, and because the heartbeat is a file-touch tickle it kept advancing, so the heartbeat-based reap never fired → silent multi-hour wedge requiring manual recovery (`Stop-Service` → `docker rm` → reset continuation → `Start-Service`).

## Fix

Re-evaluate the guard in the poll loop's **idle branch**, throttled to once per 60 s (`ROTATE_CHECK_INTERVAL_MS`). Idle is the only point with no active query holding the `.jsonl`, so the probe's rename-aside side effect is safe. On a hit, drop the continuation so the next turn starts a fresh transcript — **the same reset the manual zombie recovery performs, done pre-emptively** — capping transcript growth below the wedge zone automatically.

The throttle+probe policy is extracted into a pure, exported `evaluateMidLifeRotation` and unit-tested (7 new tests), mirroring #28's `evaluateToolStuckBudget` pattern (test the helper, don't drive the infinite loop).

## Scope (deliberately narrow — not over-claimed)

- ✅ Prevents the **accumulation** wedge (transcript growing to 21 MB across many tours).
- ❌ Does **not** address the **bunching** / single-catastrophic-tour wedge (a turn that crosses the cap and dies before returning to idle) — patch #26's 240 s watchdog (#58) + host de-bunching cover that timing.
- ❌ Does **not** reduce per-tour compaction thrash itself (the deeper `poids-par-tour` lever); it bounds the *cumulative* bloat that thrash produces.

Complements #58 (stops the false-trip) and #59 (suppresses the telemetry the thrash leaks). Independent of both — branches off `main`, touches only `poll-loop.ts` + its test + `PATCHES.md`.

## Verification

- `bun run typecheck` — clean
- `bun test` (container suite) — **182 pass / 0 fail**
- Diff vs `main`: 1 commit, 3 files (`poll-loop.ts`, `poll-loop.test.ts`, `PATCHES.md`).

## Notes

- Overlay patch **#41** (PATCHES.md). #40 is claimed by the in-flight #59; if both merge, the two PATCHES.md appends may need a trivial keep-both resolution.
- **Do not self-merge** — owner review required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)