### PR TITLE
fix(claude-md): bound CLAUDE.local.md injection at spawn

### DIFF
--- a/src/claude-md-compose.test.ts
+++ b/src/claude-md-compose.test.ts
@@ -15,6 +15,7 @@ vi.mock('./log.js', () => ({
 }));
 
 import { composeGroupClaudeMd } from './claude-md-compose.js';
+import { log } from './log.js';
 import { ensureContainerConfig, updateContainerConfigScalars } from './db/container-configs.js';
 import { closeDb, createAgentGroup, initTestDb, runMigrations } from './db/index.js';
 import { PERSONA_PREPEND_FILE } from './group-persona.js';
@@ -114,5 +115,75 @@ describe('composeGroupClaudeMd scheduling instructions (ncl tasks reach-in)', ()
     const imports = importsOf(ag.folder);
     expect(imports).not.toContain('@./.claude-fragments/module-scheduling.md');
     expect(imports).not.toContain('@./.claude-fragments/module-cli.md');
+  });
+});
+
+// The bound exercises the REAL production thresholds (64KB / 256KB) rather
+// than injected ones: the defect these guard against is a file that grew past
+// the shipped limits, so a test that moves the limits proves nothing.
+describe('CLAUDE.local.md injection bound', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function localPath(folder: string): string {
+    return path.join(GROUPS_DIR, folder, 'CLAUDE.local.md');
+  }
+  function overflowFiles(folder: string): string[] {
+    return fs.readdirSync(path.join(GROUPS_DIR, folder)).filter((f) => f.startsWith('CLAUDE.local.overflow-'));
+  }
+
+  it('leaves a file under the warn threshold untouched and silent', () => {
+    const ag = group('ag-small', 'bound-small');
+    seed(ag);
+    composeGroupClaudeMd(ag);
+    const body = 'rule\n'.repeat(200);
+    fs.writeFileSync(localPath(ag.folder), body);
+
+    composeGroupClaudeMd(ag);
+
+    expect(fs.readFileSync(localPath(ag.folder), 'utf-8')).toBe(body);
+    expect(overflowFiles(ag.folder)).toHaveLength(0);
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it('warns past the warn threshold WITHOUT mutating the file', () => {
+    const ag = group('ag-warn', 'bound-warn');
+    seed(ag);
+    composeGroupClaudeMd(ag);
+    const body = 'x'.repeat(100 * 1024);
+    fs.writeFileSync(localPath(ag.folder), body);
+
+    composeGroupClaudeMd(ag);
+
+    expect(fs.readFileSync(localPath(ag.folder), 'utf-8')).toBe(body);
+    expect(overflowFiles(ag.folder)).toHaveLength(0);
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining('oversized'),
+      expect.objectContaining({ folder: ag.folder, bytes: body.length }),
+    );
+  });
+
+  it('rotates past the bound, preserving the previous contents verbatim', () => {
+    const ag = group('ag-rotate', 'bound-rotate');
+    seed(ag);
+    composeGroupClaudeMd(ag);
+    const body = 'y'.repeat(300 * 1024);
+    fs.writeFileSync(localPath(ag.folder), body);
+
+    composeGroupClaudeMd(ag);
+
+    const archives = overflowFiles(ag.folder);
+    expect(archives).toHaveLength(1);
+    // Nothing deleted: the archive is byte-identical to what was rotated out.
+    expect(fs.readFileSync(path.join(GROUPS_DIR, ag.folder, archives[0]), 'utf-8')).toBe(body);
+    // And the injected surface is now a stub that names the archive.
+    const stub = fs.readFileSync(localPath(ag.folder), 'utf-8');
+    expect(stub.length).toBeLessThan(2048);
+    expect(stub).toContain(archives[0]);
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining('rotated'),
+      expect.objectContaining({ archive: archives[0] }),
+    );
   });
 });

--- a/src/claude-md-compose.ts
+++ b/src/claude-md-compose.ts
@@ -20,6 +20,7 @@ import { GROUPS_DIR } from './config.js';
 import type { McpServerConfig } from './container-config.js';
 import { getContainerConfig } from './db/container-configs.js';
 import { readGroupPersona } from './group-persona.js';
+import { log } from './log.js';
 import type { AgentGroup } from './types.js';
 
 // Fragment holding a template's persona prepend. Imported FIRST (before the
@@ -35,6 +36,26 @@ const SHARED_MCP_TOOLS_CONTAINER_BASE = '/app/src/mcp-tools';
 // Host-side source paths used to discover fragment sources at compose time.
 // Resolved at call time (process.cwd() = project root) so tests can swap cwd.
 const MCP_TOOLS_HOST_SUBPATH = path.join('container', 'agent-runner', 'src', 'mcp-tools');
+
+// `CLAUDE.local.md` is the agent-owned half of the injected instruction
+// surface: Claude Code auto-loads it from the group directory into the system
+// prompt on every turn. Nothing bounds its growth. Its own prose guard ("KEEP
+// THIS SECTION SMALL") is addressed to the agent that must not violate it, and
+// has been violated twice — 2026-07-19 (~280KB of DONE cycle-logs) and
+// 2026-08-26 (388KB, six days of silent autocompact-thrash before anyone
+// looked). A rule enforced only by the layer it constrains does not bound; it
+// defers.
+//
+// Two stages, because composition cannot tell a live rule from a dead log:
+//   WARN   — names the cause in the spawn logs instead of leaving the operator
+//            to discover a week of thrash after the fact. Non-mutating.
+//   ROTATE — past this size the session cannot survive its own system prompt,
+//            so the agent is already producing nothing. Archiving the file
+//            whole and leaving a pointer loses nothing, and is strictly better
+//            than the outage it replaces.
+const CLAUDE_LOCAL_FILE = 'CLAUDE.local.md';
+const CLAUDE_LOCAL_WARN_BYTES = Number(process.env.CLAUDE_LOCAL_WARN_BYTES) || 64 * 1024;
+const CLAUDE_LOCAL_ROTATE_BYTES = Number(process.env.CLAUDE_LOCAL_ROTATE_BYTES) || 256 * 1024;
 
 const COMPOSED_HEADER =
   '<!-- Composed at spawn - do not edit. Standing instructions: instructions.prepend.md. Memory: memory/. -->';
@@ -149,6 +170,57 @@ export function composeGroupClaudeMd(group: AgentGroup): void {
   }
   const body = [COMPOSED_HEADER, ...imports, ''].join('\n');
   writeAtomic(path.join(groupDir, 'CLAUDE.md'), body);
+
+  enforceClaudeLocalBound(groupDir, group.folder);
+}
+
+/**
+ * Bound the agent-owned `CLAUDE.local.md` at spawn. Warns past
+ * `CLAUDE_LOCAL_WARN_BYTES`; past `CLAUDE_LOCAL_ROTATE_BYTES` archives the file
+ * under a timestamped name and leaves a stub naming the archive. Never deletes.
+ */
+export function enforceClaudeLocalBound(groupDir: string, folder: string): void {
+  const target = path.join(groupDir, CLAUDE_LOCAL_FILE);
+  // Absent means nothing is injected, so there is nothing to bound.
+  const stat = fs.statSync(target, { throwIfNoEntry: false });
+  if (!stat) return;
+  const size = stat.size;
+  if (size < CLAUDE_LOCAL_WARN_BYTES) return;
+
+  if (size < CLAUDE_LOCAL_ROTATE_BYTES) {
+    log.warn('CLAUDE.local.md is oversized — injected into the system prompt every turn', {
+      folder,
+      bytes: size,
+      warnBytes: CLAUDE_LOCAL_WARN_BYTES,
+      rotateBytes: CLAUDE_LOCAL_ROTATE_BYTES,
+    });
+    return;
+  }
+
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const archive = `CLAUDE.local.overflow-${stamp}.md`;
+  fs.renameSync(target, path.join(groupDir, archive));
+  writeAtomic(
+    target,
+    [
+      `# CLAUDE.local.md — rotated at spawn (${size} bytes > ${CLAUDE_LOCAL_ROTATE_BYTES})`,
+      '',
+      `Previous contents preserved verbatim in \`${archive}\`. Nothing was deleted.`,
+      '',
+      'This file is injected into the system prompt on EVERY turn. At the size it',
+      'reached, the session could not survive its own prompt (autocompact thrash).',
+      '',
+      `Re-read \`${archive}\` and restore ONLY live rules and genuinely in-flight`,
+      'state. Completed cycle-logs belong in the append-only logs, never here.',
+      '',
+    ].join('\n'),
+  );
+  log.warn('CLAUDE.local.md rotated — exceeded the injection bound', {
+    folder,
+    bytes: size,
+    rotateBytes: CLAUDE_LOCAL_ROTATE_BYTES,
+    archive,
+  });
 }
 
 function syncFragment(linkPath: string, containerTarget: string, hostSource: string | undefined): void {


### PR DESCRIPTION
## Ce que ça corrige

`CLAUDE.local.md` est la moitié *agent-owned* de la surface d'instructions injectée : Claude Code la charge dans le system prompt **à chaque tour**. Rien ne bornait sa croissance. Sa seule garde était de la prose **à l'intérieur du fichier lui-même** (« KEEP THIS SECTION SMALL »), adressée à l'agent qui ne doit pas la violer.

Elle a été violée deux fois :

| Date | Taille | Conséquence |
|---|---|---|
| 2026-07-19 | ~280 Ko | Vidé à la main par l'opérateur |
| 2026-08-26 | **388 084 o** (~97k tokens/tour) | `telegram_main` en autocompact-thrash **6 jours**, production nulle, découvert seulement en cherchant pourquoi l'agent était muet (#3273) |

Une règle appliquée uniquement par la couche qu'elle contraint ne borne pas : elle diffère.

## La borne

Deux étages, parce que la composition ne peut pas distinguer une règle vivante d'un log mort :

- **WARN** (> 64 Ko, `CLAUDE_LOCAL_WARN_BYTES`) — nomme la cause dans les logs de spawn au lieu de laisser l'opérateur découvrir une semaine de thrash après coup. **Ne mute rien.**
- **ROTATE** (> 256 Ko, `CLAUDE_LOCAL_ROTATE_BYTES`) — passé cette taille la session ne survit pas à son propre prompt, donc l'agent ne produit déjà plus rien. Le fichier est archivé **entier** sous un nom horodaté et remplacé par un stub qui nomme l'archive. **Rien n'est jamais supprimé.**

Branché sur `composeGroupClaudeMd`, qui s'exécute déjà à chaque spawn.

## Ce que j'ai vérifié

- **Les gardes voisines ne sont pas en cause** : `CLAUDE_CODE_AUTO_COMPACT_WINDOW=250000` et `CLAUDE_TRANSCRIPT_ROTATE_BYTES=4194304` atteignent bien le conteneur (`docker inspect`) — PATCH-myia #38/#44 fonctionnent. Le seul axe non borné était bien celui-ci.
- **Les tests exercent les seuils réellement livrés** (64 Ko / 256 Ko), pas des seuils injectés : le défaut visé est un fichier qui a dépassé les limites *déployées*, donc un test qui déplace les limites ne prouverait rien.
- **Contre-épreuve par mutation** : en désactivant l'appel à `enforceClaudeLocalBound`, les tests *warn* et *rotate* virent au rouge (2 échecs). Le test « fichier petit » reste vert à juste titre — il affirme qu'il ne se passe rien.
- **Zéro régression** : `vitest run` complet donne **20 fichiers / 53 tests en échec sur `main` pur** comme avec ce changement (+3 tests verts). Ces 53 échecs **préexistent** et sortent du périmètre de cette PR.
- `tsc --noEmit` vert ; `eslint` revient exactement au compte de warnings de la ligne de base (3 `no-catch-all`, aucun ajouté — `statSync({ throwIfNoEntry: false })` évite le `catch`).

## Remédiation manuelle déjà appliquée

`groups/telegram_main/CLAUDE.local.md` a été purgé à la main : **388 084 → 20 946 o**. Les logs retirés sont préservés verbatim dans `pending-archive-20260826.md`, l'état complet d'avant purge dans `CLAUDE.local.md.bak-20260826`. Diffs byte-à-byte vérifiés dans les deux sens.
